### PR TITLE
build: fix sdk build within docker builds

### DIFF
--- a/samples/js-customer-registry/Dockerfile
+++ b/samples/js-customer-registry/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14-buster-slim AS builder
 WORKDIR /home/node
 RUN apt-get update && apt-get install -y curl unzip
 COPY sdk sdk
-RUN cd sdk && npm ci
+RUN cd sdk && npm ci && npm run prepare
 RUN cd sdk && npm prune --production
 COPY samples/js-customer-registry/package*.json samples/js-customer-registry/
 RUN cd samples/js-customer-registry && npm ci

--- a/samples/js-eventsourced-shopping-cart/Dockerfile
+++ b/samples/js-eventsourced-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14-buster-slim AS builder
 WORKDIR /home/node
 RUN apt-get update && apt-get install -y curl unzip
 COPY sdk sdk
-RUN cd sdk && npm ci
+RUN cd sdk && npm ci && npm run prepare
 RUN cd sdk && npm prune --production
 COPY samples/js-eventsourced-shopping-cart/package*.json samples/js-eventsourced-shopping-cart/
 RUN cd samples/js-eventsourced-shopping-cart && npm ci

--- a/samples/js-replicated-entity-example/Dockerfile
+++ b/samples/js-replicated-entity-example/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14-buster-slim AS builder
 WORKDIR /home/node
 RUN apt-get update && apt-get install -y curl unzip
 COPY sdk sdk
-RUN cd sdk && npm ci
+RUN cd sdk && npm ci && npm run prepare
 RUN cd sdk && npm prune --production
 COPY samples/js-replicated-entity-example/package*.json samples/js-replicated-entity-example/
 RUN cd samples/js-replicated-entity-example && npm ci

--- a/samples/js-valueentity-shopping-cart/Dockerfile
+++ b/samples/js-valueentity-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14-buster-slim AS builder
 WORKDIR /home/node
 RUN apt-get update && apt-get install -y curl unzip
 COPY sdk sdk
-RUN cd sdk && npm ci
+RUN cd sdk && npm ci && npm run prepare
 RUN cd sdk && npm prune --production
 COPY samples/js-valueentity-shopping-cart/package*.json samples/js-valueentity-shopping-cart/
 RUN cd samples/js-valueentity-shopping-cart && npm ci

--- a/samples/js-views-example/Dockerfile
+++ b/samples/js-views-example/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14-buster-slim AS builder
 WORKDIR /home/node
 RUN apt-get update && apt-get install -y curl unzip
 COPY sdk sdk
-RUN cd sdk && npm ci
+RUN cd sdk && npm ci && npm run prepare
 RUN cd sdk && npm prune --production
 COPY samples/js-views-example/package*.json samples/js-views-example/
 RUN cd samples/js-views-example && npm ci

--- a/tck/Dockerfile
+++ b/tck/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14-buster-slim AS builder
 WORKDIR /home/node
 RUN apt-get update && apt-get install -y curl unzip
 COPY sdk sdk
-RUN cd sdk && npm ci
+RUN cd sdk && npm ci && npm run prepare
 RUN cd sdk && npm prune --production
 COPY tck/package*.json tck/
 RUN cd tck && npm ci


### PR DESCRIPTION
Noticed by CI when publishing TCK docker image. If building from a clean repo, the SDK needs `npm run prepare` to be run explicitly when using `npm ci` in the docker build.

I'll publish the TCK docker image for `0.7.0-beta.7` manually. Should work fine for next release.