### PR TITLE
build: add settings.js to package

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -31,7 +31,8 @@
     "protobuf-bundle.d.ts",
     "src",
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "settings.js"
   ],
   "dependencies": {
     "@grpc/proto-loader": "^0.5.6",


### PR DESCRIPTION
Oops. Missed file in the packaging. Not picked up by testing, which uses the SDK locally and not packaged.
