### PR TITLE
fix: only call doclinkfor when there is a code

### DIFF
--- a/sdk/src/akkaserverless.js
+++ b/sdk/src/akkaserverless.js
@@ -263,12 +263,16 @@ class AkkaServerless {
     if (call.request.detail) {
       msg += "\n\n" + call.request.detail;
     }
-    const docLink = this.docLinkFor(call.request.code)
-    if (docLink)
-      msg += " See documentation: " + docLink
-    for (const location of (call.request.sourceLocations || [])) {
-      msg += "\n\n" + this.formatSource(location)
+
+    if(call.request.code) {
+      const docLink = this.docLinkFor(call.request.code)
+      if (docLink)
+        msg += " See documentation: " + docLink
+      for (const location of (call.request.sourceLocations || [])) {
+        msg += "\n\n" + this.formatSource(location)
+      }
     }
+    
     console.error(msg);
     callback(null, {});
   }


### PR DESCRIPTION
fixes #9 

Added an extra check to make sure that only when there's an actual error code we call the `docLinkFor()` method