### PR TITLE
fix: deserialize protobuf any with undefined values (no bytes)

### DIFF
--- a/sdk/src/protobuf-any.js
+++ b/sdk/src/protobuf-any.js
@@ -215,7 +215,7 @@ module.exports = class AnySupport {
       type = url.substr(idx + 1);
     }
 
-    let bytes = any.value;
+    let bytes = any.value || EmptyArray;
 
     if (hostName === AkkaServerlessPrimitive) {
       return AnySupport.deserializePrimitive(bytes, type);

--- a/sdk/test/protobuf-any-test.js
+++ b/sdk/test/protobuf-any-test.js
@@ -22,7 +22,6 @@ const Long = require("long");
 
 const root = new protobuf.Root();
 root.loadSync(path.join(__dirname, "example.proto"));
-
 const anySupport = new AnySupport(root);
 const Example = root.lookupType("com.example.Example");
 const PrimitiveLike = root.lookupType("com.example.PrimitiveLike");
@@ -169,6 +168,13 @@ describe("AnySupport", () => {
 
   it("should fail to serialize to JSON when no type property is present but is required", () => {
     (() => AnySupport.serialize({field1: "foo"}, false, true, true)).should.throw();
+  });
+
+  it("should handle deserializing undefined any values", () => {
+    const serialized = { type_url: "type.googleapis.com/com.example.Example" };
+    const deserialized = anySupport.deserialize(serialized);
+    deserialized.should.be.an.instanceof(Example.ctor);
+    deserialized.should.be.empty;
   });
 
 });


### PR DESCRIPTION
Noticed when sending requests with `grpcurl` and empty body. These arrive as protobuf any with undefined values, which would crash the service. Default to an empty array/buffer and check that these are deserialised as an empty message.