### PR TITLE
feat: basic type definition generation from jsdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/sdk/.gitignore
+++ b/sdk/.gitignore
@@ -2,3 +2,4 @@ proto
 protoc
 apidocs
 user-function.desc
+index.d.ts

--- a/sdk/.npmrc
+++ b/sdk/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+@janory:registry=https://npm.pkg.github.com

--- a/sdk/.npmrc
+++ b/sdk/.npmrc
@@ -1,2 +1,2 @@
 engine-strict=true
-@janory:registry=https://npm.pkg.github.com
+@lightbend:registry=https://npm.cloudsmith.io/lightbend/akkaserverless

--- a/sdk/bin/prepare.sh
+++ b/sdk/bin/prepare.sh
@@ -36,7 +36,7 @@ pbjs -t static-module -p ./proto -p ./protoc/include \
   | pbts -o ./proto/protobuf-bundle.d.ts -
 
 # Generate TS type definitions based on the JSDocs
-jsdoc -t ./node_modules/@janory/tsd-jsdoc/dist -c ./jsdoc.json -d .
+jsdoc -t ./node_modules/@lightbend/tsd-jsdoc/dist -c ./jsdoc.json -d .
 mv types.d.ts index.d.ts
 # There replacements are quite dirty, but even the patched tsd-jsdoc generator can't deal with these (mostly module related) issues currently
 perl -i -pe 's/declare module \"akkaserverless\"/declare module \"\@lightbend\/akkaserverless-javascript-sdk\"/g' index.d.ts

--- a/sdk/bin/prepare.sh
+++ b/sdk/bin/prepare.sh
@@ -34,3 +34,14 @@ pbjs -t static-module -p ./proto -p ./protoc/include \
   ./proto/akkaserverless/component/*.proto \
   ./proto/akkaserverless/component/*/*.proto \
   | pbts -o ./proto/protobuf-bundle.d.ts -
+
+# Generate TS type definitions based on the JSDocs
+jsdoc -t ./node_modules/@janory/tsd-jsdoc/dist -c ./jsdoc.json -d .
+mv types.d.ts index.d.ts
+# There replacements are quite dirty, but even the patched tsd-jsdoc generator can't deal with these (mostly module related) issues currently
+perl -i -pe 's/declare module \"akkaserverless\"/declare module \"\@lightbend\/akkaserverless-javascript-sdk\"/g' index.d.ts
+perl -i -pe 's/module:akkaserverless\.//g' index.d.ts
+perl -i -pe 's/import\("akkaserverless\.([a-zA-Z.]*)([a-zA-Z]*)\"\).(?!default\W)([a-zA-Z]*)/$1$2.$3/g' index.d.ts
+perl -i -pe 's/import\("akkaserverless\.([a-zA-Z.]*)([a-zA-Z]*)\"\)([.a-zA-Z]*)/$1$2/g' index.d.ts
+perl -i -pe 's/Promise(?!<)/Promise<any>/g' index.d.ts
+perl -i -pe 's/Component\[\]/import(\"\.\/proto\/protobuf-bundle")\.akkaserverless\.protocol\.Component\[\]/g' index.d.ts

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -131,6 +131,15 @@
         "protobufjs": "^6.8.6"
       }
     },
+    "@janory/tsd-jsdoc": {
+      "version": "2.5.1",
+      "resolved": "https://npm.pkg.github.com/download/@janory/tsd-jsdoc/2.5.1/e472ef0c56b221162c0248b0fd890f192448fc405b03517227d2d7595234c756",
+      "integrity": "sha512-EFPwAuoK0Ch3fu71L07tt0SvI0qAR3Tp+yO8xFunurUaApleCoqoUuGhZXuqxcapD0h+km7+rNgF0ufCO0Zh5Q==",
+      "dev": true,
+      "requires": {
+        "typescript": "^3.2.1"
+      }
+    },
     "@mapbox/node-pre-gyp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz",
@@ -5079,6 +5088,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
       "dev": true
     },
     "uc.micro": {

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -131,10 +131,10 @@
         "protobufjs": "^6.8.6"
       }
     },
-    "@janory/tsd-jsdoc": {
+    "@lightbend/tsd-jsdoc": {
       "version": "2.5.1",
-      "resolved": "https://npm.pkg.github.com/download/@janory/tsd-jsdoc/2.5.1/e472ef0c56b221162c0248b0fd890f192448fc405b03517227d2d7595234c756",
-      "integrity": "sha512-EFPwAuoK0Ch3fu71L07tt0SvI0qAR3Tp+yO8xFunurUaApleCoqoUuGhZXuqxcapD0h+km7+rNgF0ufCO0Zh5Q==",
+      "resolved": "https://npm.cloudsmith.io/lightbend/akkaserverless/@lightbend/tsd-jsdoc/-/2.5.1/tsd-jsdoc-2.5.1.tgz",
+      "integrity": "sha512-gcU+0BIEC6n49/1fUB0nwgMnPL08MZ1mTWyGMHed7f8nqPSt8t7y98OXov5v2czcmwWbRVfmqrg4AZOrgI5orQ==",
       "dev": true,
       "requires": {
         "typescript": "^3.2.1"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -49,7 +49,7 @@
     "unzipper": "^0.9.15"
   },
   "devDependencies": {
-    "@janory/tsd-jsdoc": "^2.5.1",
+    "@lightbend/tsd-jsdoc": "^2.5.1",
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "ink-docstrap": "^1.3.2",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -49,6 +49,7 @@
     "unzipper": "^0.9.15"
   },
   "devDependencies": {
+    "@janory/tsd-jsdoc": "^2.5.1",
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "ink-docstrap": "^1.3.2",

--- a/sdk/src/action-support.js
+++ b/sdk/src/action-support.js
@@ -36,6 +36,9 @@ class ActionSupport {
   }
 }
 
+/**
+ * @private
+ */
 class ActionHandler {
 
   constructor(support, grpcMethod, commandHandler, call, grpcCallback, metadata) {

--- a/sdk/src/action.js
+++ b/sdk/src/action.js
@@ -24,6 +24,13 @@ const AkkaServerless = require("./akkaserverless");
 const actionServices = new ActionSupport();
 
 /**
+ * Options for a action.
+ *
+ * @typedef module:akkaserverless.Action~options
+ * @property {array<string>} [includeDirs=["."]] The directories to include when looking up imported protobuf files.
+ */
+
+/**
  * A unary action command handler.
  *
  * @callback module:akkaserverless.Action~unaryCommandHandler
@@ -68,7 +75,7 @@ const actionServices = new ActionSupport();
  * An action.
  *
  * @memberOf module:akkaserverless
- * @extends module:akkaserverless.Entity
+ * @implements module:akkaserverless.Entity
  */
 class Action {
 

--- a/sdk/src/akkaserverless.js
+++ b/sdk/src/akkaserverless.js
@@ -93,7 +93,7 @@ try {
  * An Akka Serverless root server.
  *
  * @memberOf module:akkaserverless
- * @extends module:akkaserverless.Server
+ * @implements module:akkaserverless.Server
  */
 class AkkaServerless {
 
@@ -144,7 +144,7 @@ class AkkaServerless {
   /**
    * Start this server.
    *
-   * @param {module:akkaserverless.AkkaServerless~startOptions=} options The options for starting.
+   * @param {module:akkaserverless.Server~startOptions=} options The options for starting.
    * @returns {number} The port that was bound to, useful for when a random ephemeral port was requested.
    */
   start(options) {

--- a/sdk/src/command-helper.js
+++ b/sdk/src/command-helper.js
@@ -25,7 +25,7 @@ const Reply = require("./reply").Reply;
  * Creates the base for context objects.
  * @private
  */
-module.exports = class CommandHelper {
+class CommandHelper {
 
   constructor(entityId, service, streamId, call, handlerFactory, allComponents, debug) {
     this.entityId = entityId;
@@ -344,3 +344,5 @@ module.exports = class CommandHelper {
     return accessor;
   }
 };
+
+module.exports = CommandHelper;

--- a/sdk/src/event-sourced-entity-support.js
+++ b/sdk/src/event-sourced-entity-support.js
@@ -25,6 +25,9 @@ const AnySupport = require("./protobuf-any");
 const CommandHelper = require("./command-helper");
 const Reply = require("./reply").Reply;
 
+/**
+ * @private
+ */
 class EventSourcedEntitySupport {
 
   constructor(root, service, behavior, initial, options, allComponents) {

--- a/sdk/src/event-sourced-entity.js
+++ b/sdk/src/event-sourced-entity.js
@@ -95,7 +95,7 @@ const eventSourcedEntityServices = new EventSourcedEntityServices();
  * An event sourced entity.
  *
  * @memberOf module:akkaserverless
- * @extends module:akkaserverless.Entity
+ * @implements module:akkaserverless.Entity
  */
 class EventSourcedEntity {
 

--- a/sdk/src/integration-testkit.js
+++ b/sdk/src/integration-testkit.js
@@ -24,6 +24,9 @@ const defaultOptions = {
   dockerImage: `gcr.io/akkaserverless-public/akkaserverless-proxy:${settings.frameworkVersion}`
 }
 
+/**
+ * @private
+ */
 class IntegrationTestkit {
 
   constructor(options) {

--- a/sdk/src/protobuf-any.js
+++ b/sdk/src/protobuf-any.js
@@ -61,8 +61,10 @@ const AkkaServerlessJson = "json.akkaserverless.com/";
  * @type {module:akkaserverless.SerializableProtobufMessage|module:akkaserverless.TypedJson|Object|string|number|boolean|Long|Buffer}
  */
 
-
-module.exports = class AnySupport {
+/**
+ * @private
+ */
+class AnySupport {
   constructor(root) {
     this.root = root;
   }
@@ -265,3 +267,5 @@ module.exports = class AnySupport {
     return this.primitiveDefaultValue(type);
   }
 };
+
+module.exports = AnySupport;

--- a/sdk/src/replicated-data/gset.js
+++ b/sdk/src/replicated-data/gset.js
@@ -75,8 +75,8 @@ function GSet() {
   /**
    * Create an iterator for this set.
    *
-   * @function module:akkaserverless.replicatedentity.GSet#@@iterator
-   * @returns {iterator<module:akkaserverless.Serializable>}
+   * @function module:akkaserverless.replicatedentity.GSet#iterator
+   * @returns {Iterator<module:akkaserverless.Serializable>}
    */
   this[Symbol.iterator] = function () {
     return currentValue.values();

--- a/sdk/src/replicated-data/ormap.js
+++ b/sdk/src/replicated-data/ormap.js
@@ -76,7 +76,7 @@ function ORMap() {
    *
    * @callback module:akkaserverless.replicatedentity.ORMap~defaultValueCallback
    * @param {module:akkaserverless.Serializable} key The key the default value is being generated for.
-   * @returns {undefined|akkaserverless.replicatedentity.ReplicatedData} The default value, or undefined if no default value should be returned.
+   * @returns {undefined|module:akkaserverless.replicatedentity.ReplicatedData} The default value, or undefined if no default value should be returned.
    */
 
   /**
@@ -152,8 +152,8 @@ function ORMap() {
   /**
    * Return an iterator of the entries of this map.
    *
-   * @function module:akkaserverless.replicatedentity.ORMap#@@iterator
-   * @returns {iterator<Array>}
+   * @function module:akkaserverless.replicatedentity.ORMap#iterator
+   * @returns {Iterator<Array>}
    */
   this[Symbol.iterator] = function() {
     return entries();
@@ -163,7 +163,7 @@ function ORMap() {
    * Return an iterator of the values of this map.
    *
    * @function module:akkaserverless.replicatedentity.ORMap#values
-   * @returns {iterator<module:akkaserverless.replicatedentity.ReplicatedData>}
+   * @returns {Iterator<module:akkaserverless.replicatedentity.ReplicatedData>}
    */
   this.values = function() {
     return mapIterator(currentValue.values(), value => value.value);
@@ -173,7 +173,7 @@ function ORMap() {
    * Return an iterator of the keys of this map.
    *
    * @function module:akkaserverless.replicatedentity.ORMap#keys
-   * @returns {iterator<module:akkaserverless.Serializable>}
+   * @returns {Iterator<module:akkaserverless.Serializable>}
    */
   this.keys = function() {
     return mapIterator(currentValue.values(), value => value.key);
@@ -182,7 +182,7 @@ function ORMap() {
   /**
    * Get the value at the given key.
    *
-   * @function {module:akkaserverless.replicatedentity.ORMap#get}
+   * @function module:akkaserverless.replicatedentity.ORMap#get
    * @param {module:akkaserverless.Serializable} key The key to get.
    * @returns {undefined|module:akkaserverless.replicatedentity.ReplicatedData} The Replicated Data value, or undefined if no value is defined at that key.
    */

--- a/sdk/src/replicated-data/orset.js
+++ b/sdk/src/replicated-data/orset.js
@@ -79,8 +79,8 @@ function ORSet() {
   /**
    * Create an iterator for this set.
    *
-   * @function module:akkaserverless.replicatedentity.ORSet#@@iterator
-   * @returns {iterator<module:akkaserverless.Serializable>}
+   * @function module:akkaserverless.replicatedentity.ORSet#iterator
+   * @returns {Iterator<module:akkaserverless.Serializable>}
    */
   this[Symbol.iterator] = function () {
     return currentValue.values();

--- a/sdk/src/replicated-data/vote.js
+++ b/sdk/src/replicated-data/vote.js
@@ -22,7 +22,7 @@ const util = require("util");
  * A Vote Replicated Data type allows all nodes an a cluster to vote on a condition, such as whether a user is online.
  *
  * @constructor module:akkaserverless.replicatedentity.Vote
- * @extends module:akkaserverless.replicatedentity.ReplicatedData
+ * @implements module:akkaserverless.replicatedentity.ReplicatedData
  */
 function Vote() {
   let currentSelfVote = false;

--- a/sdk/src/replicated-entity.js
+++ b/sdk/src/replicated-entity.js
@@ -65,7 +65,7 @@ const replicatedEntityServices = new support.ReplicatedEntityServices();
  * A Replicated Entity.
  *
  * @memberOf module:akkaserverless.replicatedentity
- * @extends module:akkaserverless.Entity
+ * @implements module:akkaserverless.Entity
  */
 class ReplicatedEntity {
 

--- a/sdk/src/reply.js
+++ b/sdk/src/reply.js
@@ -15,9 +15,13 @@
  */
 
 /**
+ *
+ * @namespace module:akkaserverless.replies
+ */
+
+/**
  * A return type to allow returning forwards or failures, and attaching effects to messages.
  *
- * @class module:akkaserverless.replies.Reply
  * @memberOf module:akkaserverless.replies
  */
 class Reply {
@@ -59,7 +63,6 @@ class Reply {
 }
 
 /**
- * @class module:akkaserverless.replies.Effect
  * @memberOf module:akkaserverless.replies
  */
 class Effect {
@@ -80,7 +83,7 @@ class Effect {
 
 /**
  * Factory for creating various types of replies from a component
- * @member module:akkaserverless.replies
+ * @memberOf module:akkaserverless.replies
  */
 class ReplyFactory {
   /**

--- a/sdk/src/value-entity-support.js
+++ b/sdk/src/value-entity-support.js
@@ -24,6 +24,9 @@ debug.log = console.log.bind(console);
 const AnySupport = require("./protobuf-any");
 const CommandHelper = require("./command-helper");
 
+/**
+ * @private
+ */
 class ValueEntitySupport {
 
   constructor(root, service, commandHandlers, initial, options, allComponents) {

--- a/sdk/src/value-entity.js
+++ b/sdk/src/value-entity.js
@@ -25,12 +25,10 @@ const valueEntityServices = new ValueEntityServices();
 
 /**
  * Value entity command handlers
+ * The names of the properties must match the names of the service calls specified in the gRPC descriptor for this value entities service.
  *
  * @typedef module:akkaserverless.ValueEntity~commandHandlers
- *
- * The names of the properties must match the names of the service calls specified in the gRPC descriptor for this
- * value entities service.
- * @property {Object<String, module:akkaserverless.ValueEntity~commandHandler>}
+ * @type {Object<String, module:akkaserverless.ValueEntity~commandHandler>}
  */
 
 /**
@@ -69,7 +67,7 @@ const valueEntityServices = new ValueEntityServices();
  * A value entity.
  *
  * @memberOf module:akkaserverless
- * @extends module:akkaserverless.Entity
+ * @implements module:akkaserverless.Entity
  */
 class ValueEntity {
 
@@ -146,7 +144,7 @@ class ValueEntity {
   /**
    * Set the command handlers of the entity.
    *
-   * @param {module:akkaserverless.ValueEntity~commandHandlers} callback The command handler callbacks.
+   * @param {module:akkaserverless.ValueEntity~commandHandlers} handlers The command handler callbacks.
    * @return {module:akkaserverless.ValueEntity} This entity.
    */
   setCommandHandlers(commandHandlers) {

--- a/sdk/src/view.js
+++ b/sdk/src/view.js
@@ -32,12 +32,11 @@ const viewServices = new ViewServices();
 
 /**
  * View handlers
- *
- * @typedef module:akkaserverless.View~handlers
- *
  * The names of the properties must match the names of all the view methods specified in the gRPC
  * descriptor.
- * @property {Object<String, module:akkaserverless.View~handler>}
+ *
+ * @typedef module:akkaserverless.View~handlers
+ * @type {Object<String, module:akkaserverless.View~handler>}
  */
 
 /**
@@ -54,7 +53,7 @@ const viewServices = new ViewServices();
  * A view.
  *
  * @memberOf module:akkaserverless
- * @extends module:akkaserverless.Entity
+ * @implements module:akkaserverless.Entity
  */
 class View {
 


### PR DESCRIPTION
Fixes this issue https://github.com/lightbend/akkaserverless-framework/issues/689.

In order to make the JSDoc -> .d.ts generation work, I had to change a few things:
- fix JSDoc annotations/comments where the generator yielded an error (please verify if the changes make sense)
- use a patched tsd-jsdoc generator because of this issue: https://github.com/englercj/tsd-jsdoc/issues/89
- [fork and create a package](https://github.com/janory/tsd-jsdoc/packages/833291) from [englercj's PR](https://github.com/englercj/tsd-jsdoc/pull/144/files#diff-9af2ecc9ea9c57456a81fadd6bf93a6d974c4aa1421e8bf912ce080d70be4fcb)
- even the forked version didn't work fully so had to [monkey patch it](https://github.com/janory/tsd-jsdoc/commit/d5ebc54eb6e624e0bc7e56a8f73f27296a2dada3) before publishing
- add the .d.ts generation to the `prepare.sh` script with some post processing (mostly regex search & replaces) to get the correct types

Hint: I've forked the tsd-jsdoc library under my account instead of the LB organisation, because I was not sure about the licensing (the original license is MIT, so it should fine though) and legal implications. It's already a fork of a fork and I wanted to make this work quickly, I thinks it's fine to have it under my account, because it's not too much different as using package from foreign people from NPM, but I can transfer the ownership of the repo to LB if we want to.

This is the first and very basic version of the type definition support, there are plenty of TODOs which we can do to improve the generated types. 

I see the following short-term TODOs which could help us to get better typing:
- there are still lots of warnings by JSDoc during the type definition generation, we should analyze and fix those, because the generator often just falls back to `any`
- try to eliminate as much `any`s as possible by locally solving the [{object} -> any issue](https://github.com/microsoft/TypeScript/issues/18396)
- remove the dirty regexes and solve those issues on the `tsd-jsdoc` library level

A long-term TODO would be to transform the SDK's codebase to Typescript and don't rely on the JSDoc for type generation.
Since we already generate fairly accurate types based on the JSDoc this transition could happen easier and of course gradually. Based on the decision of how and when do we want to make this step, we should consider to put as less effort into the short-term TODOs as possible.