### PR TITLE
ci: remove sudo commands from circleci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,8 @@ jobs:
             pushd samples/js-eventsourced-shopping-cart && npm ci && npm test && popd
             pushd samples/js-valueentity-shopping-cart && npm ci && npm test && popd
 
-            pushd sdk && npm install && sudo npm link && popd
+            mkdir ~/.npm-packages && npm config set prefix ~/.npm-packages
+            pushd sdk && npm ci && npm link && popd
             pushd samples/valueentity-counter && npm link @lightbend/akkaserverless-javascript-sdk && npm install && npm run build && npm run test && popd
 
   integration-tests:
@@ -51,7 +52,7 @@ jobs:
             pushd samples/js-eventsourced-shopping-cart && npm ci && npm run integration-test && popd
             pushd samples/js-valueentity-shopping-cart && npm ci && npm run integration-test && popd
 
-            pushd sdk && npm install && sudo ln -s "$(which node)" /usr/bin/node && sudo ln -s "$(which npm)" /usr/bin/npm && sudo npm link && popd
+            pushd sdk && nvm install && npm ci && npm link && popd
             pushd samples/valueentity-counter && npm link @lightbend/akkaserverless-javascript-sdk && npm install && npm run build && npm run integration-test && popd
 
   tck-tests:


### PR DESCRIPTION
Remove the sudo commands from CI builds, which are likely causing permission issues.

Prefer [`npm ci`](https://docs.npmjs.com/cli/v7/commands/npm-ci) for the SDK. Use `nvm` for node version management.

I've left these linked SDK tests as standalone, but we could move the `npm link` up to the sdk build and test command at some point.