### PR TITLE
get rid of allComponents

### DIFF
--- a/sdk/src/action-support.js
+++ b/sdk/src/action-support.js
@@ -27,12 +27,12 @@ const CloudEvents = require("./cloudevents");
 const Reply = require("./reply").Reply;
 
 class ActionSupport {
-  constructor(root, service, commandHandlers, allComponents) {
+  constructor(root, service, commandHandlers) {
     this.root = root;
     this.service = service;
     this.commandHandlers = commandHandlers;
     this.anySupport = new AnySupport(this.root);
-    this.effectSerializer = new EffectSerializer(allComponents);
+    this.effectSerializer = new EffectSerializer();
   }
 }
 
@@ -509,9 +509,8 @@ module.exports = class ActionServices {
     this.services = {};
   }
 
-  addService(component, allComponents) {
-    this.services[component.serviceName] = new ActionSupport(component.root, component.service,
-        component.commandHandlers, allComponents);
+  addService(component) {
+    this.services[component.serviceName] = new ActionSupport(component.root, component.service, component.commandHandlers);
   }
 
   componentType() {

--- a/sdk/src/action-support.js
+++ b/sdk/src/action-support.js
@@ -32,7 +32,6 @@ class ActionSupport {
     this.service = service;
     this.commandHandlers = commandHandlers;
     this.anySupport = new AnySupport(this.root);
-    this.effectSerializer = new EffectSerializer();
   }
 }
 
@@ -255,7 +254,7 @@ class ActionHandler {
       this.ctx.alreadyReplied = true;
       if (!internalCall)
         console.warn("WARNING: Action context 'forward' is deprecated. Please use 'ReplyFactory.forward' instead.");
-      const forward = this.support.effectSerializer.serializeEffect(method, message, metadata);
+      const forward = EffectSerializer.serializeEffect(method, message, metadata);
       this.grpcCallback(null, {
         forward: forward,
         sideEffects: effects
@@ -294,7 +293,7 @@ class ActionHandler {
       if (!internalCall)
         console.warn("WARNING: Action context 'effect' is deprecated. Please use 'Reply.addEffect' instead.");
       this.streamDebug("Emitting effect to %s", method);
-      effects.push(this.support.effectSerializer.serializeSideEffect(method, message, synchronous, metadata));
+      effects.push(EffectSerializer.serializeSideEffect(method, message, synchronous, metadata));
     };
 
     this.ctx.fail = error => {
@@ -364,7 +363,7 @@ class ActionHandler {
     this.ctx.forward = (method, message, metadata) => {
       this.ensureNotCancelled();
       this.streamDebug("Forwarding to %s", method);
-      const forward = this.support.effectSerializer.serializeEffect(method, message, metadata);
+      const forward = EffectSerializer.serializeEffect(method, message, metadata);
       this.call.write({
         forward: forward,
         sideEffects: effects
@@ -404,7 +403,7 @@ class ActionHandler {
       if (!internalCall)
         console.warn("WARNING: Action context 'effect' is deprecated. Please use 'Reply.addEffect' instead.");
       this.streamDebug("Emitting effect to %s", method);
-      effects.push(this.support.effectSerializer.serializeSideEffect(method, message, synchronous, metadata));
+      effects.push(EffectSerializer.serializeSideEffect(method, message, synchronous, metadata));
     };
 
     this.ctx.fail = error => {

--- a/sdk/src/action.js
+++ b/sdk/src/action.js
@@ -134,8 +134,8 @@ class Action {
     return this.root.lookupType(messageType);
   }
 
-  register(allComponents) {
-    actionServices.addService(this, allComponents);
+  register() {
+    actionServices.addService(this);
     return actionServices;
   }
 

--- a/sdk/src/akkaserverless.js
+++ b/sdk/src/akkaserverless.js
@@ -157,14 +157,9 @@ class AkkaServerless {
       ...options
     };
 
-    const allComponentsMap = {};
-    this.components.forEach(component => {
-      allComponentsMap[component.serviceName] = component.service;
-    });
-
     const componentTypes = {};
     this.components.forEach(component => {
-      const componentServices = component.register(allComponentsMap);
+      const componentServices = component.register();
       componentTypes[componentServices.componentType()] = componentServices;
     });
 

--- a/sdk/src/command-helper.js
+++ b/sdk/src/command-helper.js
@@ -27,12 +27,12 @@ const Reply = require("./reply").Reply;
  */
 class CommandHelper {
 
-  constructor(entityId, service, streamId, call, handlerFactory, allComponents, debug) {
+  constructor(entityId, service, streamId, call, handlerFactory, debug) {
     this.entityId = entityId;
     this.service = service;
     this.streamId = streamId;
     this.call = call;
-    this.effectSerializer = new EffectSerializer(allComponents);
+    this.effectSerializer = new EffectSerializer();
     this.debug = debug;
     this.handlerFactory = handlerFactory;
   }

--- a/sdk/src/command-helper.js
+++ b/sdk/src/command-helper.js
@@ -32,7 +32,6 @@ class CommandHelper {
     this.service = service;
     this.streamId = streamId;
     this.call = call;
-    this.effectSerializer = new EffectSerializer();
     this.debug = debug;
     this.handlerFactory = handlerFactory;
   }
@@ -158,7 +157,7 @@ class CommandHelper {
         ctx.reply.commandId = ctx.commandId;
         if (userReply.effects) {
           ctx.reply.sideEffects = userReply.effects.map(effect =>
-            this.effectSerializer.serializeSideEffect(effect.method, effect.message, effect.synchronous, effect.metadata)
+            EffectSerializer.serializeSideEffect(effect.method, effect.message, effect.synchronous, effect.metadata)
           )
         }
         if (userReply.message) {
@@ -171,7 +170,7 @@ class CommandHelper {
           ctx.commandDebug("%s reply with type [%s] with %d side effects.", desc, ctx.reply.clientAction.reply.payload.type_url, ctx.effects.length);
         } else if (userReply.forward) {
           ctx.reply.clientAction = {
-            forward: this.effectSerializer.serializeEffect(
+            forward: EffectSerializer.serializeEffect(
               userReply.forward.method, userReply.forward.message, userReply.forward.metadata)
           }
           ctx.commandDebug("%s forward to %s with %d side effects.", desc, userReply.forward.method, ctx.effects.length);
@@ -289,7 +288,7 @@ class CommandHelper {
         accessor.ensureActive();
         if (!internalCall)
           console.warn("WARNING: Command context 'effect' is deprecated. Please use 'Reply.addEffect' instead.");
-        accessor.effects.push(this.effectSerializer.serializeSideEffect(method, message, synchronous, metadata))
+        accessor.effects.push(EffectSerializer.serializeSideEffect(method, message, synchronous, metadata))
       },
 
       // FIXME: remove for version 0.8 (https://github.com/lightbend/akkaserverless-framework/issues/410)
@@ -319,7 +318,7 @@ class CommandHelper {
         accessor.ensureActive();
         if (!internalCall)
           console.warn("WARNING: Command context 'forward' is deprecated. Please use 'ReplyFactory.forward' instead.");
-        accessor.forward = this.effectSerializer.serializeEffect(method, message, metadata);
+        accessor.forward = EffectSerializer.serializeEffect(method, message, metadata);
       },
 
       /**

--- a/sdk/src/effect-serializer.js
+++ b/sdk/src/effect-serializer.js
@@ -19,9 +19,7 @@ const util = require("util");
 
 module.exports = class EffectSerializer {
 
-  constructor(allComponents) {
-    this.allComponents = allComponents;
-  }
+  constructor() {}
 
   serializeEffect(method, message, metadata) {
     let serviceName, commandName;
@@ -38,30 +36,24 @@ module.exports = class EffectSerializer {
       commandName = method.name;
     }
 
-    const service = this.allComponents[serviceName];
+    const command = method;
+    if (command !== undefined) {
+      const payload = AnySupport.serialize(command.resolvedRequestType.create(message), false, false);
+      const effect = {
+        serviceName: serviceName,
+        commandName: commandName,
+        payload: payload
+      };
 
-    if (service !== undefined) {
-      const command = service.methods[commandName];
-      if (command !== undefined) {
-        const payload = AnySupport.serialize(command.resolvedRequestType.create(message), false, false);
-        const effect = {
-          serviceName: serviceName,
-          commandName: commandName,
-          payload: payload
-        };
-
-        if (metadata && metadata.entries) {
-          effect.metadata = {
-            entries: metadata.entries
-          }
+      if (metadata && metadata.entries) {
+        effect.metadata = {
+          entries: metadata.entries
         }
-
-        return effect;
-      } else {
-        throw new Error(util.format("Command [%s] unknown on service [%s].", commandName, serviceName))
       }
+
+      return effect;
     } else {
-      throw new Error(util.format("Service [%s] has not been registered as an entity in this user function, and so can't be used as a side effect or forward.", service))
+      throw new Error(util.format("Command [%s] unknown on service [%s].", commandName, serviceName))
     }
   }
 

--- a/sdk/src/event-sourced-entity-support.js
+++ b/sdk/src/event-sourced-entity-support.js
@@ -30,14 +30,13 @@ const Reply = require("./reply").Reply;
  */
 class EventSourcedEntitySupport {
 
-  constructor(root, service, behavior, initial, options, allComponents) {
+  constructor(root, service, behavior, initial, options) {
     this.root = root;
     this.service = service;
     this.behavior = behavior;
     this.initial = initial;
     this.options = options;
     this.anySupport = new AnySupport(this.root);
-    this.allComponents = allComponents;
     if (!this.options.snapshotEvery)
       console.warn("Snapshotting disabled for entity " + this.option.entityType + ", this is not recommended.")
   }
@@ -91,7 +90,7 @@ class EventSourcedEntityHandler {
     this.streamId = Math.random().toString(16).substr(2, 7);
 
     this.commandHelper = new CommandHelper(this.entityId, support.service, this.streamId, call,
-      this.commandHandlerFactory.bind(this), support.allComponents, debug);
+      this.commandHandlerFactory.bind(this), debug);
 
     this.streamDebug("Started new stream")
   }
@@ -258,9 +257,9 @@ module.exports = class EventSourcedEntityServices {
     this.services = {};
   }
 
-  addService(entity, allComponents) {
+  addService(entity) {
     this.services[entity.serviceName] = new EventSourcedEntitySupport(entity.root, entity.service, entity.behavior,
-      entity.initial, entity.options, allComponents);
+      entity.initial, entity.options);
   }
 
   componentType() {

--- a/sdk/src/replicated-entity-support.js
+++ b/sdk/src/replicated-entity-support.js
@@ -34,12 +34,12 @@ class ReplicatedEntityServices {
     ];
   }
 
-  addService(entity, allComponents) {
+  addService(entity) {
     this.services[entity.serviceName] = new ReplicatedEntitySupport(entity.root, entity.service, {
       commandHandlers: entity.commandHandlers,
       onStateSet: entity.onStateSet,
       defaultValue: entity.defaultValue
-    }, allComponents);
+    });
   }
 
   componentType() {
@@ -112,14 +112,13 @@ class ReplicatedEntityServices {
 
 class ReplicatedEntitySupport {
 
-  constructor(root, service, handlers, allComponents) {
+  constructor(root, service, handlers) {
     this.root = root;
     this.service = service;
     this.anySupport = new AnySupport(this.root);
     this.commandHandlers = handlers.commandHandlers;
     this.onStateSet = handlers.onStateSet;
     this.defaultValue = handlers.defaultValue;
-    this.allComponents = allComponents;
   }
 
   create(call, init) {
@@ -170,7 +169,7 @@ class ReplicatedEntityHandler {
     this.streamId = Math.random().toString(16).substr(2, 7);
 
     this.commandHelper = new CommandHelper(this.entityId, support.service, this.streamId, call,
-      this.commandHandlerFactory.bind(this), support.allComponents, debug);
+      this.commandHandlerFactory.bind(this), debug);
 
     this.streamDebug("Started new stream");
 

--- a/sdk/src/replicated-entity.js
+++ b/sdk/src/replicated-entity.js
@@ -150,8 +150,8 @@ class ReplicatedEntity {
     return this.root.lookupType(messageType);
   }
 
-  register(allComponents) {
-    replicatedEntityServices.addService(this, allComponents);
+  register() {
+    replicatedEntityServices.addService(this);
     return replicatedEntityServices;
   }
 

--- a/sdk/src/value-entity-support.js
+++ b/sdk/src/value-entity-support.js
@@ -29,14 +29,13 @@ const CommandHelper = require("./command-helper");
  */
 class ValueEntitySupport {
 
-  constructor(root, service, commandHandlers, initial, options, allComponents) {
+  constructor(root, service, commandHandlers, initial, options) {
     this.root = root;
     this.service = service;
     this.commandHandlers = commandHandlers;
     this.initial = initial;
     this.options = options;
     this.anySupport = new AnySupport(this.root);
-    this.allComponents = allComponents;
   }
 
   serialize(obj, requireJsonType) {
@@ -86,7 +85,7 @@ class ValueEntityHandler {
     this.streamId = Math.random().toString(16).substr(2, 7);
 
     this.commandHelper = new CommandHelper(this.entityId, support.service, this.streamId, call,
-      this.commandHandlerFactory.bind(this), support.allComponents, debug);
+      this.commandHandlerFactory.bind(this), debug);
 
     this.streamDebug("Started new stream")
   }
@@ -212,9 +211,9 @@ module.exports = class ValueEntityServices {
     this.services = {};
   }
 
-  addService(entity, allComponents) {
+  addService(entity) {
     this.services[entity.serviceName] = new ValueEntitySupport(entity.root, entity.service, entity.commandHandlers,
-      entity.initial, entity.options, allComponents);
+      entity.initial, entity.options);
   }
 
   componentType() {

--- a/sdk/src/value-entity.js
+++ b/sdk/src/value-entity.js
@@ -152,8 +152,8 @@ class ValueEntity {
     return this;
   }
 
-  register(allComponents) {
-    valueEntityServices.addService(this, allComponents);
+  register() {
+    valueEntityServices.addService(this);
     return valueEntityServices;
   }
 

--- a/sdk/src/view-support.js
+++ b/sdk/src/view-support.js
@@ -31,7 +31,7 @@ module.exports = class ViewServices {
     this.services = {};
   }
 
-  addService(component, allComponents) {
+  addService(component) {
     this.services[component.serviceName] = component;
   }
 

--- a/sdk/src/view.js
+++ b/sdk/src/view.js
@@ -118,8 +118,8 @@ class View {
     return this;
   }
 
-  register(allComponents) {
-    viewServices.addService(this, allComponents);
+  register() {
+    viewServices.addService(this);
     return viewServices;
   }
 

--- a/sdk/test/action-handler-test.js
+++ b/sdk/test/action-handler-test.js
@@ -79,8 +79,6 @@ class MockUnaryCall {
 
 function createAction(handler) {
   const actionSupport = new ActionSupport()
-  const allComponents = {}
-  allComponents[ExampleServiceName] = ExampleService
   actionSupport.addService({
     root: root,
     serviceName: ExampleServiceName,
@@ -88,7 +86,7 @@ function createAction(handler) {
     commandHandlers: {
       DoSomething: handler
     }
-  }, allComponents)
+  })
   return actionSupport
 }
 


### PR DESCRIPTION
Here we stop passing around `allComponents` to each and every class.

The only reason (at best of my understanding) we have been doing so was to look up the function in `effect-serializer`, but the method itself is passed as a first argument.

Anything I'm missing?