### PR TITLE
fix: always publish to npmjs registry

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -87,5 +87,8 @@
     "prepare": "bin/prepare.sh",
     "postinstall": "node bin/download-protoc.js",
     "prepublishOnly": "npm version --no-git-tag-version $(bin/version.sh)"
+  },
+  "publishConfig": {
+    "@lightbend:registry": "https://registry.npmjs.org"
   }
 }


### PR DESCRIPTION
Resolves #50. Alternative fix to #45. I've checked this by publishing `0.7.0-beta.10`, which failed to publish in CI and works with this config override now.