### PR TITLE
Prevent dirty versions when releasing npm packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,9 @@ jobs:
           command: |
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
             pushd sdk && npm ci && npm publish --access public && popd
+            git reset --hard HEAD
             pushd npm-js/create-akkasls-entity && npm publish --access public && popd
+            git reset --hard HEAD
             pushd npm-js/akkasls-scripts && npm publish --access public && popd
 
   publish-tck:


### PR DESCRIPTION
The release is changing `package.json` and the "next" publishing becomes "dirty".
e.g.:
https://www.npmjs.com/package/@lightbend/create-akkasls-entity/v/0.30.0-beta.1-0-add67021-dev