### PR TITLE
fix: change type to look for constructor

### DIFF
--- a/sdk/src/protobuf-any.js
+++ b/sdk/src/protobuf-any.js
@@ -211,7 +211,7 @@ class AnySupport {
         value: obj.constructor.encode(obj).finish(),
       });
     } else if (fallbackToJson && typeof obj === 'object') {
-      let type = obj.type;
+      let type = obj.constructor;
       if (type === undefined) {
         if (requireJsonType) {
           throw new Error(


### PR DESCRIPTION
Change the object type to look for constructor instead of a field in the message called `type`

Solved https://github.com/lightbend/akkaserverless-javascript-sdk/issues/84