### PR TITLE
build: compile SDK protocol directly for codegen

### DIFF
--- a/codegen/build.sbt
+++ b/codegen/build.sbt
@@ -24,11 +24,13 @@ lazy val `akkasls-codegen-core` =
     .settings(commonSettings)
     .settings(
       libraryDependencies ++= Seq(
-        library.akkaserverless,
+        library.akkaserverless % "protobuf-src",
+        library.scalapbRuntime % "protobuf",
         library.protobufJava,
         library.munit           % Test,
         library.munitScalaCheck % Test
-      )
+      ),
+      Compile / PB.targets := Seq(PB.gens.java -> (Compile / sourceManaged).value)
     )
 
 lazy val `akkasls-codegen-js` =
@@ -116,6 +118,7 @@ lazy val `akkasls-codegen-js-cli` =
 lazy val library =
   new {
     object Version {
+      val akkaserverless = "0.7.0-beta.9"
       val commonsIo      = "2.8.0"
       val kiama          = "2.4.0"
       val logback        = "1.2.3"
@@ -125,7 +128,6 @@ lazy val library =
       val scopt          = "4.0.0"
       val testcontainers = "1.15.3"
       val typesafeConfig = "1.4.1"
-      val akkaserverless = "0.7.0-beta.9"
     }
     val commonsIo       = "commons-io"                     % "commons-io"       % Version.commonsIo
     val kiama           = "org.bitbucket.inkytonik.kiama" %% "kiama"            % Version.kiama
@@ -138,7 +140,9 @@ lazy val library =
     val testcontainers  = "org.testcontainers"             % "testcontainers"   % Version.testcontainers
     val typesafeConfig  = "com.typesafe"                   % "config"           % Version.typesafeConfig
     val akkaserverless =
-      "com.akkaserverless" % "akkaserverless-java-sdk" % Version.akkaserverless
+      "com.akkaserverless" % "akkaserverless-sdk-protocol" % Version.akkaserverless
+    val scalapbRuntime =
+      "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion
   }
 
 // *****************************************************************************

--- a/codegen/project/plugins.sbt
+++ b/codegen/project/plugins.sbt
@@ -5,3 +5,7 @@ addSbtPlugin("org.wartremover"   % "sbt-wartremover"  % "2.4.13")
 addSbtPlugin("org.scalameta"     % "sbt-native-image" % "0.3.0")
 addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo"    % "0.10.0")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"     % "0.15.0")
+
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.2")
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.3"


### PR DESCRIPTION
Codegen shouldn't be depending on the Java SDK for the akkaserverless annotations. Compile the SDK protocol directly instead, with the akkaserverless version for the protocol/proxy.

Also including in #89 to check the bump to the new protocol.