### PR TITLE
chore(docs): fix correct stylization of macOS

### DIFF
--- a/docs/src/modules/javascript/pages/kickstart.adoc
+++ b/docs/src/modules/javascript/pages/kickstart.adoc
@@ -139,7 +139,7 @@ You can run your services locally and test them manually with HTTP or gRPC reque
 . To start the proxy, run the following command from the top-level project directory:
 +
 [.tabset]
-MacOS, Windows::
+macOS, Windows::
 +
 --
 [source,bash]

--- a/docs/src/modules/javascript/partials/running-service-locally.adoc
+++ b/docs/src/modules/javascript/partials/running-service-locally.adoc
@@ -19,7 +19,7 @@ To start the proxy, run the following command from the directory with the `docke
 . Start the proxy
 +
 [.tabset]
-Mac and Windows::
+macOS and Windows::
 +
 --
 [source, command line]


### PR DESCRIPTION
Updated the docs to reflect the correct stylization of macOS (lowercase m, uppercase OS)