### PR TITLE
tck: add view source entity

### DIFF
--- a/tck/index.js
+++ b/tck/index.js
@@ -40,6 +40,7 @@ server.addComponent(localPersistenceEventing.valueEntityTwo);
 server.addComponent(localPersistenceEventing.localPersistenceSubscriber);
 const view = require('./view.js');
 server.addComponent(view.tckModel);
+server.addComponent(view.viewSource);
 server.start();
 
 module.exports = server;

--- a/tck/view.js
+++ b/tck/view.js
@@ -15,6 +15,8 @@
  */
 
 const View = require('@lightbend/akkaserverless-javascript-sdk').View;
+const ValueEntity =
+  require('@lightbend/akkaserverless-javascript-sdk').ValueEntity;
 
 const tckModel = new View(
   'proto/view.proto',
@@ -47,4 +49,11 @@ function processUpdateUnary(userEvent, previousViewState, ctx) {
   }
 }
 
+const viewSource = new ValueEntity(
+  ['proto/view.proto'],
+  'akkaserverless.tck.model.view.ViewTckSource',
+  'view-source',
+);
+
 module.exports.tckModel = tckModel;
+module.exports.viewSource = viewSource;


### PR DESCRIPTION
The proxy will have eventing source validation, so the view in the TCK needs an existing entity as its source now.

See https://github.com/lightbend/akkaserverless-framework/pull/774 and https://github.com/lightbend/akkaserverless-framework/pull/773