### PR TITLE
tck: fix docker build for tck image

### DIFF
--- a/tck/Dockerfile
+++ b/tck/Dockerfile
@@ -1,13 +1,14 @@
 FROM node:14-buster-slim AS builder
-WORKDIR /home/node
 RUN apt-get update && apt-get install -y curl unzip
-COPY sdk sdk
-RUN cd sdk && npm ci && npm run prepare
-RUN cd sdk && npm prune --production
-COPY tck/package*.json tck/
-RUN cd tck && npm ci
-COPY tck tck
-RUN cd tck && npm run build
+WORKDIR /home/node
+USER node
+COPY --chown=node sdk sdk
+RUN cd sdk && npm ci
+RUN cd sdk && npm pack
+COPY --chown=node tck/package.json tck/
+COPY --chown=node tck/bin tck/bin
+RUN cd tck && npm install
+COPY --chown=node tck tck
 RUN cd tck && npm prune --production
 
 FROM node:14-buster-slim


### PR DESCRIPTION
Update the docker build for the tck after the changes in #77.

And when node runs as root it won't run other task dependencies (so install doesn't run prepare, pack doesn't run prepack, and so on). Rather than run these tasks explicitly, switch to running as the node user for the build parts as well. Still in separate steps for cached builds.

We don't test anything with these docker images (including the samples), maybe something to follow up on, or otherwise just something to deal with when we update the use of these elsewhere.

