### PR TITLE
doc: fail warnings and errors, like unresolved includes

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,7 +11,7 @@ managed_examples := ${src_managed}/modules/${module}/examples
 managed_partials := ${src_managed}/modules/${module}/partials
 
 antora_docker_image := gcr.io/akkaserverless-public/akkaserverless-docbuilder
-antora_docker_image_tag := 0.0.4
+antora_docker_image_tag := 0.0.5
 root_dir := $(shell git rev-parse --show-toplevel)
 base_path := $(shell git rev-parse --show-prefix)
 
@@ -52,7 +52,7 @@ dev-html:
 		--rm \
 		--entrypoint /bin/sh \
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
-		-c "cd /antora/${base_path} && antora --cache-dir=.cache/antora --stacktrace dev/antora.yml"
+		-c "cd /antora/${base_path} && antora --cache-dir=.cache/antora --stacktrace --log-failure-level=warn dev/antora.yml"
 	@echo "Generated docs at dev/build/site/javascript/index.html"
 
 validate-xrefs:


### PR DESCRIPTION
With the new doc builder using antora 3 (alpha pre-release), the build can be failed on warnings or errors. Previously these would only be logged and the build succeed.

So this covers includes not found:

```
[01:15:58.779] ERROR (asciidoctor): target of include not found: example$some/unknown/file.js
    file: /antora/docs/src/modules/javascript/pages/value-entity.adoc:26
    source: /antora (refname: fail-unresolved-includes <worktree>, start path: docs/src)

make: *** [dev-html] Error 1
```

Or callouts not found:

```
[01:15:58.789] WARN (asciidoctor): no callout found for <1>
    file: /antora/docs/src/modules/javascript/pages/value-entity.adoc:29
    source: /antora (refname: fail-unresolved-includes <worktree>, start path: docs/src)
```
 