### PR TITLE
fix: report errors as being from Akka Serverless system

### DIFF
--- a/sdk/src/akkaserverless.ts
+++ b/sdk/src/akkaserverless.ts
@@ -364,7 +364,7 @@ export class AkkaServerless {
     detail: string | undefined,
     locations: Array<discovery.UserFunctionError.SourceLocation> | undefined,
   ) {
-    let msg = `Error reported from Akka system: ${code} ${message}`;
+    let msg = `Error reported from Akka Serverless system: ${code} ${message}`;
     if (detail) {
       msg += `\n\n${detail}`;
     }

--- a/sdk/test/akkaserverless.test.ts
+++ b/sdk/test/akkaserverless.test.ts
@@ -118,7 +118,7 @@ describe('Akkaserverless', () => {
     );
 
     // Assert
-    const result = `Error reported from Akka system: AS-00112 test message
+    const result = `Error reported from Akka Serverless system: AS-00112 test message
 
 test details See documentation: https://developer.lightbend.com/docs/akka-serverless/javascript/views.html#changing
 


### PR DESCRIPTION
Small correction to error reporting. Make it from `Akka Serverless system` rather than `Akka system`. Same as Java SDK now.