### PR TITLE
Add doc links for entity eventing error codes

### DIFF
--- a/sdk/src/akkaserverless.ts
+++ b/sdk/src/akkaserverless.ts
@@ -86,6 +86,9 @@ class DocLink {
     ['AS-00112', 'javascript/views.html#changing'],
     ['AS-00402', 'javascript/topic-eventing.html'],
     ['AS-00406', 'javascript/topic-eventing.html'],
+    ['AS-00414', 'javascript/entity-eventing.html'],
+    // TODO: docs for value entity eventing (https://github.com/lightbend/akkaserverless-javascript-sdk/issues/103)
+    // ['AS-00415', 'javascript/entity-eventing.html'],
   ]);
   private codeCategories: Map<string, string> = new Map([
     ['AS-001', 'javascript/views.html'],
@@ -372,7 +375,7 @@ export class AkkaServerless {
     if (code) {
       const docLink = this.docLink.getLink(code);
       if (docLink.length > 0)
-        msg += ` See documentation: ${this.docLink.getLink(code)}`;
+        msg += `\nSee documentation: ${this.docLink.getLink(code)}`;
       for (const location of locations || []) {
         msg += `\n\n${this.formatSource(location)}`;
       }

--- a/sdk/test/akkaserverless.test.ts
+++ b/sdk/test/akkaserverless.test.ts
@@ -120,7 +120,8 @@ describe('Akkaserverless', () => {
     // Assert
     const result = `Error reported from Akka system: AS-00112 test message
 
-test details See documentation: https://developer.lightbend.com/docs/akka-serverless/javascript/views.html#changing
+test details
+See documentation: https://developer.lightbend.com/docs/akka-serverless/javascript/views.html#changing
 
 At package.test.json:2:4:
   "name": "some-name",


### PR DESCRIPTION
Add doc links for the new error codes for eventing validation for entity types (https://github.com/lightbend/akkaserverless-framework/pull/773). Note that the docs currently only cover subscribing to event sourced entities (doc issue #103).

Also use a newline before the doc link — which creates tidier formatting, and more similar to the Java SDK.