### PR TITLE
ci: fix java versions for macOS builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
             sudo sh -c 'for bin in /usr/lib/jvm/jdk-11.0.8+10/bin/*; do update-alternatives --install /usr/bin/$(basename $bin) $(basename $bin) $bin 100; done'
             sudo sh -c 'for bin in /usr/lib/jvm/jdk-11.0.8+10/bin/*; do update-alternatives --set $(basename $bin) $bin; done'
 
-  install-java-11-osx:
+  install-java-11-macos:
     description: install openjdk-11
     steps:
       - run:
@@ -38,6 +38,8 @@ commands:
           command: |
             brew update
             brew install openjdk@11
+            # brew-installed sbt uses openjdk for default java home
+            ln -sfn /usr/local/opt/openjdk@11 /usr/local/opt/openjdk
 
   install-java-11-win:
     description: install openjdk-11
@@ -62,10 +64,10 @@ commands:
             sudo dpkg -i sbt-<< parameters.version >>.deb
             rm sbt-<< parameters.version >>.deb
 
-  setup_sbt_osx:
+  setup_sbt_macos:
     description: "Set up sbt"
     steps:
-      - install-java-11-osx
+      - install-java-11-macos
       - run:
           name: Install sbt
           environment:
@@ -74,7 +76,8 @@ commands:
             # Call brew update explicitly until Circle CI update their images,
             # see https://github.com/Homebrew/brew/issues/11123
             brew update
-            brew install sbt
+            # don't install openjdk dependency (currently @16)
+            brew install sbt --ignore-dependencies
 
   setup_sbt_win:
     description: "Set up sbt"
@@ -412,13 +415,13 @@ jobs:
           version: $(sdk/bin/version.sh)
       - save_deps_cache
 
-  publish_native_osx:
+  publish_native_macos:
     macos:
       xcode: 12.5.0
-    description: "Build Native image on OsX"
+    description: "Build Native image on macOS"
     steps:
       - checkout
-      - setup_sbt_osx
+      - setup_sbt_macos
       - run:
           name: Build Native Image
           working_directory: "~/project/codegen"
@@ -545,7 +548,7 @@ workflows:
             - validate-docs
             - npm-js-tests
             - e2e-tests
-      - publish_native_osx:
+      - publish_native_macos:
           context:
             - cloudsmith
           filters: # version tags only


### PR DESCRIPTION
The macOS native image build failed for 0.31.0 release, as sbt was running with openjdk 16:

https://app.circleci.com/pipelines/github/lightbend/akkaserverless-javascript-sdk/426/workflows/64b38cfe-fd38-4729-bae4-488022d479de/jobs/2037

This must have changed at some point since last release, where sbt depends on brew-installed openjdk by default, and this is now JDK 16. There are a few ways to fix this. There is an AdoptOpenJDK 11 install with the OS already. And JAVA_HOME can be specified. I've opted to link openjdk@11 as the default openjdk, and not install the openjdk dependency for sbt, so that using the sbt command as is will run with the explicitly installed openjdk by default.

For 0.31.0, I've manually published the native image for macOS (from the CI machine, with rerun job with ssh).