### PR TITLE
feat: move write consistency to overall replicated entity settings

### DIFF
--- a/sdk/index.js
+++ b/sdk/index.js
@@ -27,6 +27,8 @@ module.exports.ReplicatedEntity =
   require('./src/replicated-entity').ReplicatedEntity;
 module.exports.ReplicatedData =
   require('./src/replicated-entity').ReplicatedData;
+module.exports.ReplicatedWriteConsistency =
+  require('./src/akkaserverless').ReplicatedWriteConsistency;
 module.exports.Action = require('./src/action');
 module.exports.Metadata = require('./src/metadata');
 module.exports.IntegrationTestkit =

--- a/sdk/src/akkaserverless.ts
+++ b/sdk/src/akkaserverless.ts
@@ -59,6 +59,23 @@ export interface EntityPassivationStrategy {
   timeout?: number;
 }
 
+export enum ReplicatedWriteConsistency {
+  /**
+   * Updates will only be written to the local replica immediately, and then asynchronously
+   * distributed to other replicas in the background.
+   */
+  LOCAL,
+  /**
+   * Updates will be written immediately to a majority of replicas, and then asynchronously
+   * distributed to remaining replicas in the background.
+   */
+  MAJORITY,
+  /**
+   * Updates will be written immediately to all replicas.
+   */
+  ALL,
+}
+
 export interface ComponentOptions {
   includeDirs?: Array<string>;
   forwardHeaders?: Array<string>;
@@ -69,6 +86,7 @@ export interface EntityOptions {
   includeDirs?: Array<string>;
   entityPassivationStrategy?: EntityPassivationStrategy;
   forwardHeaders?: Array<string>;
+  replicatedWriteConsistency?: ReplicatedWriteConsistency;
 }
 
 export interface Component {
@@ -438,6 +456,28 @@ export class AkkaServerless {
           }
           if (entityOptions.forwardHeaders) {
             entitySettings.setForwardHeadersList(entityOptions.forwardHeaders);
+          }
+          if (entityOptions.replicatedWriteConsistency) {
+            let writeConsistency =
+              discovery.ReplicatedWriteConsistency
+                .REPLICATED_WRITE_CONSISTENCY_LOCAL_UNSPECIFIED;
+            switch (entityOptions.replicatedWriteConsistency) {
+              case ReplicatedWriteConsistency.ALL:
+                writeConsistency =
+                  discovery.ReplicatedWriteConsistency
+                    .REPLICATED_WRITE_CONSISTENCY_ALL;
+                break;
+              case ReplicatedWriteConsistency.MAJORITY:
+                writeConsistency =
+                  discovery.ReplicatedWriteConsistency
+                    .REPLICATED_WRITE_CONSISTENCY_MAJORITY;
+                break;
+              default:
+                writeConsistency =
+                  discovery.ReplicatedWriteConsistency
+                    .REPLICATED_WRITE_CONSISTENCY_LOCAL_UNSPECIFIED;
+            }
+            entitySettings.setReplicatedWriteConsistency(writeConsistency);
           }
 
           res.setEntity(entitySettings);

--- a/sdk/src/akkaserverless.ts
+++ b/sdk/src/akkaserverless.ts
@@ -458,6 +458,7 @@ export class AkkaServerless {
             entitySettings.setForwardHeadersList(entityOptions.forwardHeaders);
           }
           if (entityOptions.replicatedWriteConsistency) {
+            const replicatedEntitySettings = new discovery.ReplicatedEntitySettings();
             let writeConsistency =
               discovery.ReplicatedWriteConsistency
                 .REPLICATED_WRITE_CONSISTENCY_LOCAL_UNSPECIFIED;
@@ -477,7 +478,9 @@ export class AkkaServerless {
                   discovery.ReplicatedWriteConsistency
                     .REPLICATED_WRITE_CONSISTENCY_LOCAL_UNSPECIFIED;
             }
-            entitySettings.setReplicatedWriteConsistency(writeConsistency);
+            replicatedEntitySettings.setWriteConsistency(writeConsistency);
+            entitySettings.setReplicatedEntity(replicatedEntitySettings);
+            console.log("ENTITY SETTINGS", entitySettings);
           }
 
           res.setEntity(entitySettings);

--- a/sdk/src/replicated-data/index.js
+++ b/sdk/src/replicated-data/index.js
@@ -68,37 +68,6 @@ const Clocks = (function () {
   return Object.freeze(values);
 })();
 
-/**
- * A write consistency setting for replication of state updates.
- *
- * @typedef module:akkaserverless.replicatedentity.WriteConsistency
- */
-
-/**
- * An enum of write consistency settings, for replication of state updates.
- *
- * @name module:akkaserverless.replicatedentity.WriteConsistencies
- * @enum {module:akkaserverless.replicatedentity.WriteConsistency}
- * @property LOCAL Updates will only be written to the local replica immediately, and then asynchronously
- *                 distributed to other replicas in the background.
- * @property MAJORITY Updates will be written immediately to a majority of replicas, and then asynchronously
- *                    distributed to remaining replicas in the background.
- * @property ALL Updates will be written immediately to all replicas.
- */
-const WriteConsistencies = (function () {
-  const ReplicatedEntityWriteConsistency =
-    protobufHelper.moduleRoot.akkaserverless.component.replicatedentity
-      .ReplicatedEntityWriteConsistency;
-  const values = {
-    LOCAL:
-      ReplicatedEntityWriteConsistency.REPLICATED_ENTITY_WRITE_CONSISTENCY_LOCAL_UNSPECIFIED,
-    MAJORITY:
-      ReplicatedEntityWriteConsistency.REPLICATED_ENTITY_WRITE_CONSISTENCY_MAJORITY,
-    ALL: ReplicatedEntityWriteConsistency.REPLICATED_ENTITY_WRITE_CONSISTENCY_ALL,
-  };
-  return Object.freeze(values);
-})();
-
 function createForDelta(delta) {
   if (delta.counter) {
     return new ReplicatedCounter();
@@ -124,5 +93,4 @@ module.exports = {
   ReplicatedMap: ReplicatedMap,
   Vote: Vote,
   Clocks: Clocks,
-  WriteConsistencies: WriteConsistencies,
 };

--- a/sdk/src/replicated-entity-support.js
+++ b/sdk/src/replicated-entity-support.js
@@ -300,17 +300,6 @@ class ReplicatedEntityHandler {
           get: () => ctx.streamed === true,
         });
 
-        /**
-         * Set the write consistency for replication of Replicated Entity state.
-         *
-         * @name module:akkaserverless.replicatedentity.ReplicatedEntityCommandContext#writeConsistency
-         * @type {module:akkaserverless.replicatedentity.WriteConsistency}
-         */
-        Object.defineProperty(ctx.context, 'writeConsistency', {
-          get: () => ctx.writeConsistency,
-          set: (writeConsistency) => (ctx.writeConsistency = writeConsistency),
-        });
-
         const userReply = await this.entity.commandHandlers[commandName](
           command,
           ctx.context,
@@ -340,7 +329,6 @@ class ReplicatedEntityHandler {
       ctx.commandDebug('Deleting entity');
       ctx.reply.stateAction = {
         delete: {},
-        writeConsistency: ctx.writeConsistency,
       };
       this.currentState = null;
       await this.handleStateChange();
@@ -350,7 +338,6 @@ class ReplicatedEntityHandler {
         ctx.commandDebug('Updating entity');
         ctx.reply.stateAction = {
           update: delta,
-          writeConsistency: ctx.writeConsistency,
         };
         await this.handleStateChange();
       }

--- a/sdk/src/replicated-entity.js
+++ b/sdk/src/replicated-entity.js
@@ -202,8 +202,7 @@ class ReplicatedEntity {
  *   ReplicatedMap: function(): void,
  *   Vote: function(): void,
  *   Clocks: unknown[],
- *   WriteConsistencies: unknown[]
- * },
+ * }
  * ReplicatedEntity: module:akkaserverless.replicatedentity.ReplicatedEntity
  * }}
  */
@@ -216,6 +215,5 @@ module.exports = {
     ReplicatedMap: replicatedData.ReplicatedMap,
     Vote: replicatedData.Vote,
     Clocks: replicatedData.Clocks,
-    WriteConsistencies: replicatedData.WriteConsistencies,
   },
 };

--- a/tck/replicated-entity.js
+++ b/tck/replicated-entity.js
@@ -17,6 +17,7 @@
 const sdk = require('@lightbend/akkaserverless-javascript-sdk');
 const ReplicatedEntity = sdk.ReplicatedEntity;
 const ReplicatedData = sdk.ReplicatedData;
+const ReplicatedWriteConsistency = sdk.ReplicatedWriteConsistency;
 
 const tckModel = new ReplicatedEntity(
   'proto/replicated_entity.proto',
@@ -58,20 +59,6 @@ function process(request, context) {
     context.state = createReplicatedData(context.entityId);
   request.actions.forEach((action) => {
     if (action.update) {
-      if (
-        action.update.writeConsistency ===
-        ReplicatedData.WriteConsistencies.LOCAL
-      )
-        context.writeConsistency = ReplicatedData.WriteConsistencies.LOCAL;
-      else if (
-        action.update.writeConsistency ===
-        ReplicatedData.WriteConsistencies.MAJORITY
-      )
-        context.writeConsistency = ReplicatedData.WriteConsistencies.MAJORITY;
-      else if (
-        action.update.writeConsistency === ReplicatedData.WriteConsistencies.ALL
-      )
-        context.writeConsistency = ReplicatedData.WriteConsistencies.ALL;
       applyUpdate(action.update, context.state);
     } else if (action.delete) {
       context.delete();
@@ -242,6 +229,7 @@ const configured = new ReplicatedEntity(
     entityPassivationStrategy: {
       timeout: 100, // milliseconds
     },
+    replicatedWriteConsistency: ReplicatedWriteConsistency.ALL,
   },
 );
 


### PR DESCRIPTION
Depends on https://github.com/lightbend/akkaserverless-framework/pull/795 being published first.

Move write consistency from a per-update setting to an overall replicated entity setting.