### PR TITLE
test: fix test setup so that they all run again

### DIFF
--- a/sdk/.gitignore
+++ b/sdk/.gitignore
@@ -5,5 +5,3 @@ apidocs
 user-function.desc
 index.d.ts
 *.tgz
-test/example_pb.d.ts
-test/example_grpc_pb.d.ts

--- a/sdk/bin/compile-protobuf.sh
+++ b/sdk/bin/compile-protobuf.sh
@@ -34,11 +34,14 @@ $PROTOC \
     ${PWD}/proto/akkaserverless/component/*/*.proto
 
 # Compile test protos
+rm -rf test/proto
+cp -r proto test/
+
 OUT_DIR="${PWD}/test/proto"
-TS_OUT_DIR="${PWD}/test"
+TS_OUT_DIR="${PWD}/test/proto"
 
 $PROTOC \
-    --proto_path="${PWD}/proto/" \
+    --proto_path="${PWD}/test/proto/" \
     --proto_path="${PWD}/test/" \
     --plugin=protoc-gen-ts=$PROTOC_GEN_TS_PATH \
     --plugin=protoc-gen-grpc=${PROTOC_GEN_GRPC_PATH} \

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -86,7 +86,7 @@
     "print-version": "echo $npm_package_version",
     "watch-jsdoc": "npm-watch jsdoc",
     "jsdoc": "jsdoc -c jsdoc.json",
-    "test": "mocha ./test/*.test.* ./test/**/*.* --recursive --unhandled-rejections=strict",
+    "test": "mocha --exclude '**/proto/**/*' --recursive --unhandled-rejections=strict",
     "integration-test": "npm run compile && mocha integration-test",
     "preintegration-test": "bin/compile-descriptor.js test/example.proto --descriptor_set_out=integration-test/user-function.desc",
     "prepare": "bin/prepare.sh",


### PR DESCRIPTION
Since #92 looks like we stopped running all the tests. https://github.com/lightbend/akkaserverless-javascript-sdk/pull/92/commits/46ba10723c1514b9bde4222dfb59a8e763fcd3ff ended up updating so that only the replicated data tests were [running](https://app.circleci.com/pipelines/github/lightbend/akkaserverless-javascript-sdk/380/workflows/27859c17-21a9-467c-9031-fd27f8c116e2/jobs/1697) -> `77 passing`.

This reverts some of the changes for compiling the test protobufs, and rather than trying to include particular tests, this uses mocha's exclude/ignore to not run compiled proto as tests.

I'll check this works in CI too, but all tests running again -> `149 passing`