### PR TITLE
fix: set default value for forwardHeaders in JSDoc

### DIFF
--- a/sdk/src/action.js
+++ b/sdk/src/action.js
@@ -28,7 +28,7 @@ const actionServices = new ActionSupport();
  *
  * @typedef module:akkaserverless.Action~options
  * @property {array<string>} [includeDirs=["."]] The directories to include when looking up imported protobuf files.
- * @property {array<string>} forwardHeaders request headers to be forwarded as metadata to the action
+ * @property {array<string>} [forwardHeaders=[]] request headers to be forwarded as metadata to the action
  */
 
 /**

--- a/sdk/src/event-sourced-entity.js
+++ b/sdk/src/event-sourced-entity.js
@@ -89,7 +89,7 @@ const eventSourcedEntityServices = new EventSourcedEntityServices();
  * serializing events and snapshots.
  * @property {boolean} [serializeFallbackToJson=false] Whether serialization should fallback to using JSON if an event
  * or snapshot can't be serialized as a protobuf.
- * @property {array<string>} forwardHeaders request headers to be forwarded as metadata to the event sourced entity
+ * @property {array<string>} [forwardHeaders=[]] request headers to be forwarded as metadata to the event sourced entity
  */
 
 /**

--- a/sdk/src/value-entity.js
+++ b/sdk/src/value-entity.js
@@ -61,7 +61,7 @@ const valueEntityServices = new ValueEntityServices();
  * serializing the state.
  * @property {boolean} [serializeFallbackToJson=false] Whether serialization should fallback to using JSON if the state
  * can't be serialized as a protobuf.
- * @property {array<string>} forwardHeaders request headers to be forwarded as metadata to the value entity
+ * @property {array<string>} [forwardHeaders=[]] request headers to be forwarded as metadata to the value entity
  */
 
 /**


### PR DESCRIPTION
Since the TS' type generation is currently based on the JSDoc annotations, this fix is necessary in order to be able to correctly generate the types for the options fields.