### PR TITLE
feat: add specialised replicated maps

### DIFF
--- a/codegen/build.sbt
+++ b/codegen/build.sbt
@@ -118,7 +118,7 @@ lazy val `akkasls-codegen-js-cli` =
 lazy val library =
   new {
     object Version {
-      val akkaserverless = "0.7.0-beta.14"
+      val akkaserverless = "0.7.0-beta.16"
       val commonsIo      = "2.8.0"
       val kiama          = "2.4.0"
       val logback        = "1.2.3"

--- a/codegen/js-gen-cli/src/it/resources/application.conf
+++ b/codegen/js-gen-cli/src/it/resources/application.conf
@@ -4,5 +4,5 @@ akkaserverless-npm-js {
 }
 
 akkaserverless-proxy {
-    image = "gcr.io/akkaserverless-public/akkaserverless-proxy:0.7.0-beta.14"
+    image = "gcr.io/akkaserverless-public/akkaserverless-proxy:0.7.0-beta.16"
 }

--- a/npm-js/create-akkasls-entity/template/base/docker-compose.yml
+++ b/npm-js/create-akkasls-entity/template/base/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   akka-serverless-proxy:
-    image: gcr.io/akkaserverless-public/akkaserverless-proxy:0.7.0-beta.14
+    image: gcr.io/akkaserverless-public/akkaserverless-proxy:0.7.0-beta.16
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/js-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/js-eventsourced-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   akka-serverless-proxy:
-    image: gcr.io/akkaserverless-public/akkaserverless-proxy:0.7.0-beta.14
+    image: gcr.io/akkaserverless-public/akkaserverless-proxy:0.7.0-beta.16
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/js-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/js-valueentity-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   akka-serverless-proxy:
-    image: gcr.io/akkaserverless-public/akkaserverless-proxy:0.7.0-beta.14
+    image: gcr.io/akkaserverless-public/akkaserverless-proxy:0.7.0-beta.16
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/valueentity-counter/docker-compose.yml
+++ b/samples/valueentity-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   akka-serverless-proxy:
-    image: gcr.io/akkaserverless-public/akkaserverless-proxy:0.7.0-beta.14
+    image: gcr.io/akkaserverless-public/akkaserverless-proxy:0.7.0-beta.16
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/sdk/config.json
+++ b/sdk/config.json
@@ -1,3 +1,3 @@
 {
-  "frameworkVersion": "0.7.0-beta.14"
+  "frameworkVersion": "0.7.0-beta.16"
 }

--- a/sdk/src/replicated-data/counter-map.js
+++ b/sdk/src/replicated-data/counter-map.js
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const ReplicatedMap = require('./map');
+const ReplicatedCounter = require('./counter');
+
+/**
+ * @classdesc A replicated map of counters.
+ *
+ * @constructor module:akkaserverless.replicatedentity.ReplicatedCounterMap
+ * @implements module:akkaserverless.replicatedentity.ReplicatedData
+ *
+ * @param {module:akkaserverless.replicatedentity.ReplicatedMap} [initialMap] An already initialised replicated map underlying this counter map.
+ */
+function ReplicatedCounterMap(initialMap) {
+  const map = initialMap !== undefined ? initialMap : new ReplicatedMap();
+
+  /**
+   * Get the value at the given key.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedCounterMap#get
+   * @param {module:akkaserverless.Serializable} key The key to get.
+   * @returns {number|undefined} The counter value, or undefined if no value is defined at that key.
+   */
+  this.get = (key) => {
+    const counter = map.get(key);
+    return counter !== undefined ? counter.value : undefined;
+  };
+
+  /**
+   * Get the value as a long at the given key.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedCounterMap#getLong
+   * @param {module:akkaserverless.Serializable} key The key to get.
+   * @returns {Long|undefined} The counter value as a long, or undefined if no value is defined at that key.
+   */
+  this.getLong = (key) => {
+    const counter = map.get(key);
+    return counter !== undefined ? counter.longValue : undefined;
+  };
+
+  /**
+   * Increment the counter at the given key by the given number.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedCounterMap#increment
+   * @param {module:akkaserverless.Serializable} key The key for the counter to increment.
+   * @param {Long|number} increment The amount to increment the counter by. If negative, it will be decremented instead.
+   * @returns {module:akkaserverless.replicatedentity.ReplicatedCounterMap} This counter map.
+   */
+  this.increment = function (key, increment) {
+    let counter = map.get(key);
+    if (counter === undefined) {
+      counter = new ReplicatedCounter();
+      map.set(key, counter);
+    }
+    counter.increment(increment);
+    return this;
+  };
+
+  /**
+   * Decrement the counter at the given key by the given number.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedCounterMap#decrement
+   * @param {module:akkaserverless.Serializable} key The key for the counter to decrement.
+   * @param {Long|number} decrement The amount to decrement the counter by. If negative, it will be decremented instead.
+   * @returns {module:akkaserverless.replicatedentity.ReplicatedCounterMap} This counter map.
+   */
+  this.decrement = function (key, decrement) {
+    let counter = map.get(key);
+    if (counter === undefined) {
+      counter = new ReplicatedCounter();
+      map.set(key, counter);
+    }
+    counter.decrement(decrement);
+    return this;
+  };
+
+  /**
+   * Check whether this map contains a value of the given key.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedCounterMap#has
+   * @param {module:akkaserverless.Serializable} key The key to check.
+   * @returns {boolean} True if this counter map contains a value for the given key.
+   */
+  this.has = function (key) {
+    return map.has(key);
+  };
+
+  /**
+   * The number of elements in this map.
+   *
+   * @name module:akkaserverless.replicatedentity.ReplicatedCounterMap#size
+   * @type {number}
+   * @readonly
+   */
+  Object.defineProperty(this, 'size', {
+    get: function () {
+      return map.size;
+    },
+  });
+
+  /**
+   * Return an iterator of the keys of this counter map.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedCounterMap#keys
+   * @returns {IterableIterator<module:akkaserverless.Serializable>}
+   */
+  this.keys = function () {
+    return map.keys();
+  };
+
+  /**
+   * Delete the counter at the given key.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedCounterMap#delete
+   * @param {module:akkaserverless.Serializable} key The key to delete.
+   * @return {module:akkaserverless.replicatedentity.ReplicatedCounterMap} This counter map.
+   */
+  this.delete = function (key) {
+    map.delete(key);
+    return this;
+  };
+
+  /**
+   * Clear all counters from this counter map.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedCounterMap#clear
+   * @return {module:akkaserverless.replicatedentity.ReplicatedCounterMap} This counter map.
+   */
+  this.clear = function () {
+    map.clear();
+    return this;
+  };
+
+  this.getAndResetDelta = function (initial) {
+    return map.getAndResetDelta(initial);
+  };
+
+  this.applyDelta = function (delta, anySupport, createForDelta) {
+    map.applyDelta(delta, anySupport, createForDelta);
+  };
+
+  this.toString = function () {
+    return (
+      'ReplicatedCounterMap(' +
+      Array.from(map.entries())
+        .map(([key, counter]) => key + ' -> ' + counter.value)
+        .join(', ') +
+      ')'
+    );
+  };
+}
+
+module.exports = ReplicatedCounterMap;

--- a/sdk/src/replicated-data/index.js
+++ b/sdk/src/replicated-data/index.js
@@ -21,6 +21,8 @@ const ReplicatedCounter = require('./counter');
 const ReplicatedSet = require('./set');
 const ReplicatedRegister = require('./register');
 const ReplicatedMap = require('./map');
+const ReplicatedCounterMap = require('./counter-map');
+const ReplicatedRegisterMap = require('./register-map');
 const Vote = require('./vote');
 
 const Empty = protobufHelper.moduleRoot.google.protobuf.Empty;
@@ -93,6 +95,8 @@ module.exports = {
   ReplicatedSet: ReplicatedSet,
   ReplicatedRegister: ReplicatedRegister,
   ReplicatedMap: ReplicatedMap,
+  ReplicatedCounterMap: ReplicatedCounterMap,
+  ReplicatedRegisterMap: ReplicatedRegisterMap,
   Vote: Vote,
   Clocks: Clocks,
 };

--- a/sdk/src/replicated-data/index.js
+++ b/sdk/src/replicated-data/index.js
@@ -82,6 +82,10 @@ function createForDelta(delta) {
     return new ReplicatedRegister(Empty.create({}));
   } else if (delta.replicatedMap) {
     return new ReplicatedMap();
+  } else if (delta.replicatedCounterMap) {
+    return new ReplicatedCounterMap();
+  } else if (delta.replicatedRegisterMap) {
+    return new ReplicatedRegisterMap();
   } else if (delta.vote) {
     return new Vote();
   } else {

--- a/sdk/src/replicated-data/index.js
+++ b/sdk/src/replicated-data/index.js
@@ -23,6 +23,7 @@ const ReplicatedRegister = require('./register');
 const ReplicatedMap = require('./map');
 const ReplicatedCounterMap = require('./counter-map');
 const ReplicatedRegisterMap = require('./register-map');
+const ReplicatedMultiMap = require('./multi-map');
 const Vote = require('./vote');
 
 const Empty = protobufHelper.moduleRoot.google.protobuf.Empty;
@@ -86,6 +87,8 @@ function createForDelta(delta) {
     return new ReplicatedCounterMap();
   } else if (delta.replicatedRegisterMap) {
     return new ReplicatedRegisterMap();
+  } else if (delta.replicatedMultiMap) {
+    return new ReplicatedMultiMap();
   } else if (delta.vote) {
     return new Vote();
   } else {
@@ -101,6 +104,7 @@ module.exports = {
   ReplicatedMap: ReplicatedMap,
   ReplicatedCounterMap: ReplicatedCounterMap,
   ReplicatedRegisterMap: ReplicatedRegisterMap,
+  ReplicatedMultiMap: ReplicatedMultiMap,
   Vote: Vote,
   Clocks: Clocks,
 };

--- a/sdk/src/replicated-data/iterators.js
+++ b/sdk/src/replicated-data/iterators.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Internal utility functions for iterators
+
+// Map an iterator to a new iterator
+function map(iter, f) {
+  const mapped = {
+    [Symbol.iterator]: () => mapped,
+    next: () => {
+      const next = iter.next();
+      if (next.done) {
+        return {
+          done: true,
+        };
+      } else {
+        return {
+          value: f(next.value),
+          done: false,
+        };
+      }
+    },
+  };
+  return mapped;
+}
+
+module.exports = {
+  map: map,
+};

--- a/sdk/src/replicated-data/map.js
+++ b/sdk/src/replicated-data/map.js
@@ -281,16 +281,12 @@ function ReplicatedMap() {
   this.delete = function (key) {
     const comparable = AnySupport.toComparable(key);
     if (currentValue.has(comparable)) {
-      if (currentValue.size === 1) {
-        this.clear();
+      currentValue.delete(comparable);
+      if (delta.added.has(comparable)) {
+        delta.added.delete(comparable);
       } else {
-        currentValue.delete(comparable);
-        if (delta.added.has(comparable)) {
-          delta.added.delete(comparable);
-        } else {
-          const serializedKey = AnySupport.serialize(key, true, true);
-          delta.removed.set(comparable, serializedKey);
-        }
+        const serializedKey = AnySupport.serialize(key, true, true);
+        delta.removed.set(comparable, serializedKey);
       }
     }
     return this;

--- a/sdk/src/replicated-data/map.js
+++ b/sdk/src/replicated-data/map.js
@@ -17,26 +17,7 @@
 const debug = require('debug')('akkaserverless-replicated-entity');
 const util = require('util');
 const AnySupport = require('../protobuf-any');
-
-function mapIterator(iter, f) {
-  const mapped = {
-    [Symbol.iterator]: () => mapped,
-    next: () => {
-      const next = iter.next();
-      if (next.done) {
-        return {
-          done: true,
-        };
-      } else {
-        return {
-          value: f(next.value),
-          done: false,
-        };
-      }
-    },
-  };
-  return mapped;
-}
+const iterators = require('./iterators');
 
 /**
  * @classdesc A Replicated Map data type.
@@ -124,7 +105,7 @@ function ReplicatedMap() {
    */
   this.entries = function () {
     // For some reason, these arrays are key, value, even though callbacks are passed value, key
-    return mapIterator(currentValue.values(), (value) => [
+    return iterators.map(currentValue.values(), (value) => [
       value.key,
       value.value,
     ]);
@@ -147,7 +128,7 @@ function ReplicatedMap() {
    * @returns {Iterator<module:akkaserverless.replicatedentity.ReplicatedData>}
    */
   this.values = function () {
-    return mapIterator(currentValue.values(), (value) => value.value);
+    return iterators.map(currentValue.values(), (value) => value.value);
   };
 
   /**
@@ -157,7 +138,7 @@ function ReplicatedMap() {
    * @returns {Iterator<module:akkaserverless.Serializable>}
    */
   this.keys = function () {
-    return mapIterator(currentValue.values(), (value) => value.key);
+    return iterators.map(currentValue.values(), (value) => value.key);
   };
 
   /**

--- a/sdk/src/replicated-data/multi-map.js
+++ b/sdk/src/replicated-data/multi-map.js
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const debug = require('debug')('akkaserverless-replicated-entity');
+const ReplicatedSet = require('./set');
+const AnySupport = require('../protobuf-any');
+const iterators = require('./iterators');
+const util = require('util');
+
+/**
+ * @classdesc A replicated multimap (map of sets).
+ *
+ * A replicated map that maps keys to values, where each key may be associated with multiple values.
+ *
+ * @constructor module:akkaserverless.replicatedentity.ReplicatedMultiMap
+ * @implements module:akkaserverless.replicatedentity.ReplicatedData
+ */
+function ReplicatedMultiMap() {
+  const entries = new Map();
+  const removed = new Map();
+  let cleared = false;
+
+  const EmptySet = Object.freeze(new Set());
+
+  /**
+   * Get the values for the given key.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedMultiMap#get
+   * @param {module:akkaserverless.Serializable} key The key of the entry.
+   * @returns {Set<module:akkaserverless.Serializable>} The current values at the given key, or an empty Set.
+   */
+  this.get = (key) => {
+    const entry = entries.get(AnySupport.toComparable(key));
+    return entry !== undefined ? entry.values.elements() : EmptySet;
+  };
+
+  /**
+   * Store a key-value pair.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedMultiMap#put
+   * @param {module:akkaserverless.Serializable} key The key of the entry.
+   * @param {module:akkaserverless.Serializable} value The value to add to the entry.
+   * @returns {module:akkaserverless.replicatedentity.ReplicatedMultiMap} This multimap.
+   */
+  this.put = function (key, value) {
+    this.getOrCreateValues(key).add(value);
+    return this;
+  };
+
+  /**
+   * Store multiple values for a key.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedMultiMap#putAll
+   * @param {module:akkaserverless.Serializable} key The key of the entry.
+   * @param {Iterator<module:akkaserverless.Serializable>} values The values to add to the entry.
+   * @returns {module:akkaserverless.replicatedentity.ReplicatedMultiMap} This multimap.
+   */
+  this.putAll = function (key, values) {
+    this.getOrCreateValues(key).addAll(values);
+    return this;
+  };
+
+  /**
+   * Delete a single key-value pair for the given key and value.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedMultiMap#delete
+   * @param {module:akkaserverless.Serializable} key The key of the entry.
+   * @param {module:akkaserverless.Serializable} value The value to remove from the entry.
+   * @return {module:akkaserverless.replicatedentity.ReplicatedMultiMap} This multimap.
+   */
+  this.delete = function (key, value) {
+    const comparableKey = AnySupport.toComparable(key);
+    const entry = entries.get(comparableKey);
+    if (entry) {
+      entry.values.delete(value);
+      if (entry.values.size === 0) this.deleteAll(key);
+    }
+    return this;
+  };
+
+  /**
+   * Delete all values associated with the given key.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedMultiMap#deleteAll
+   * @param {module:akkaserverless.Serializable} key The key of the entry.
+   * @return {module:akkaserverless.replicatedentity.ReplicatedMultiMap} This multimap.
+   */
+  this.deleteAll = function (key) {
+    const comparableKey = AnySupport.toComparable(key);
+    if (entries.has(comparableKey)) {
+      entries.delete(comparableKey);
+      removed.set(comparableKey, key);
+    }
+    return this;
+  };
+
+  /**
+   * Check whether this multimap contains at least one value for the given key.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedMultiMap#has
+   * @param {module:akkaserverless.Serializable} key The key to check.
+   * @returns {boolean} True if this multimap contains any values for the given key.
+   */
+  this.has = function (key) {
+    return entries.has(AnySupport.toComparable(key));
+  };
+
+  /**
+   * Check whether this multimap contains the given value associated with the given key.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedMultiMap#hasValue
+   * @param {module:akkaserverless.Serializable} key The key to check.
+   * @param {module:akkaserverless.Serializable} value The value to check.
+   * @returns {boolean} True if the key-value pair is in this multimap.
+   */
+  this.hasValue = function (key, value) {
+    const comparableKey = AnySupport.toComparable(key);
+    const entry = entries.get(comparableKey);
+    return entry ? entry.values.has(value) : false;
+  };
+
+  /**
+   * The total number of values stored in the multimap.
+   *
+   * @name module:akkaserverless.replicatedentity.ReplicatedMultiMap#size
+   * @type {number}
+   * @readonly
+   */
+  Object.defineProperty(this, 'size', {
+    get: function () {
+      return Array.from(entries.values()).reduce(
+        (sum, entry) => sum + entry.values.size,
+        0,
+      );
+    },
+  });
+
+  /**
+   * The number of keys with values stored in the multimap.
+   *
+   * @name module:akkaserverless.replicatedentity.ReplicatedMultiMap#keysSize
+   * @type {number}
+   * @readonly
+   */
+  Object.defineProperty(this, 'keysSize', {
+    get: function () {
+      return entries.size;
+    },
+  });
+
+  /**
+   * Return an iterator of the keys of this multimap.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedMultiMap#keys
+   * @returns {IterableIterator<module:akkaserverless.Serializable>}
+   */
+  this.keys = function () {
+    return iterators.map(entries.values(), (entry) => entry.key);
+  };
+
+  /**
+   * Clear all entries from this multimap.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedMultiMap#clear
+   * @return {module:akkaserverless.replicatedentity.ReplicatedMultiMap} This multimap.
+   */
+  this.clear = function () {
+    if (entries.size > 0) {
+      cleared = true;
+      entries.clear();
+      removed.clear();
+    }
+    return this;
+  };
+
+  this.getOrCreateValues = function (key) {
+    const comparableKey = AnySupport.toComparable(key);
+    const entry = entries.get(comparableKey);
+    if (entry) {
+      return entry.values;
+    } else {
+      const values = new ReplicatedSet();
+      entries.set(comparableKey, { key: key, values: values });
+      return values;
+    }
+  };
+
+  this.getAndResetDelta = function (initial) {
+    const updated = [];
+    entries.forEach(({ key: key, values: values }, comparableKey) => {
+      const delta = values.getAndResetDelta();
+      if (delta !== null) {
+        updated.push({
+          key: AnySupport.serialize(key, true, true),
+          delta: delta.replicatedSet,
+        });
+      }
+    });
+    if (cleared || removed.size > 0 || updated.length > 0 || initial) {
+      const delta = {
+        replicatedMultiMap: {
+          cleared: cleared,
+          removed: Array.from(removed.values()).map((key) =>
+            AnySupport.serialize(key, true, true),
+          ),
+          updated: updated,
+        },
+      };
+      cleared = false;
+      removed.clear();
+      return delta;
+    } else {
+      return null;
+    }
+  };
+
+  this.applyDelta = function (delta, anySupport) {
+    if (!delta.replicatedMultiMap) {
+      throw new Error(
+        util.format('Cannot apply delta %o to ReplicatedMultiMap', delta),
+      );
+    }
+    if (delta.replicatedMultiMap.cleared) {
+      entries.clear();
+    }
+    if (delta.replicatedMultiMap.removed) {
+      delta.replicatedMultiMap.removed.forEach((serializedKey) => {
+        const key = anySupport.deserialize(serializedKey);
+        const comparableKey = AnySupport.toComparable(key);
+        if (entries.has(comparableKey)) {
+          entries.delete(comparableKey);
+        } else {
+          debug('Key to delete [%o] is not in ReplicatedMultiMap', key);
+        }
+      });
+    }
+    if (delta.replicatedMultiMap.updated) {
+      delta.replicatedMultiMap.updated.forEach((entry) => {
+        const key = anySupport.deserialize(entry.key);
+        this.getOrCreateValues(key).applyDelta(
+          { replicatedSet: entry.delta },
+          anySupport,
+        );
+      });
+    }
+  };
+
+  this.toString = function () {
+    return (
+      'ReplicatedMultiMap(' +
+      Array.from(entries.values())
+        .map(
+          (entry) =>
+            entry.key + ' -> (' + Array.from(entry.values).join(', ') + ')',
+        )
+        .join(', ') +
+      ')'
+    );
+  };
+}
+
+module.exports = ReplicatedMultiMap;

--- a/sdk/src/replicated-data/register-map.js
+++ b/sdk/src/replicated-data/register-map.js
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const ReplicatedMap = require('./map');
+const ReplicatedRegister = require('./register');
+
+/**
+ * @classdesc A replicated map of registers.
+ *
+ * @constructor module:akkaserverless.replicatedentity.ReplicatedRegisterMap
+ * @implements module:akkaserverless.replicatedentity.ReplicatedData
+ *
+ * @param {module:akkaserverless.replicatedentity.ReplicatedMap} [initialMap] An already initialised replicated map underlying this register map.
+ */
+function ReplicatedRegisterMap(initialMap) {
+  const map = initialMap !== undefined ? initialMap : new ReplicatedMap();
+
+  /**
+   * Get the value at the given key.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedRegisterMap#get
+   * @param {module:akkaserverless.Serializable} key The key to get.
+   * @returns {number|undefined} The register value, or undefined if no value is defined at that key.
+   */
+  this.get = (key) => {
+    const register = map.get(key);
+    return register !== undefined ? register.value : undefined;
+  };
+
+  /**
+   * Set the register at the given key to the given value.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedRegisterMap#set
+   * @param {module:akkaserverless.Serializable} key The key for the register.
+   * @param {module:akkaserverless.Serializable} value The new value for the register.
+   * @returns {module:akkaserverless.replicatedentity.ReplicatedRegisterMap} This register map.
+   */
+  this.set = function (key, value) {
+    let register = map.get(key);
+    if (register === undefined) {
+      register = new ReplicatedRegister(value);
+      map.set(key, register);
+    } else {
+      register.value = value;
+    }
+    return this;
+  };
+
+  /**
+   * Check whether this map contains a value of the given key.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedRegisterMap#has
+   * @param {module:akkaserverless.Serializable} key The key to check.
+   * @returns {boolean} True if this register map contains a value for the given key.
+   */
+  this.has = function (key) {
+    return map.has(key);
+  };
+
+  /**
+   * The number of elements in this map.
+   *
+   * @name module:akkaserverless.replicatedentity.ReplicatedRegisterMap#size
+   * @type {number}
+   * @readonly
+   */
+  Object.defineProperty(this, 'size', {
+    get: function () {
+      return map.size;
+    },
+  });
+
+  /**
+   * Return an iterator of the keys of this register map.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedRegisterMap#keys
+   * @returns {IterableIterator<module:akkaserverless.Serializable>}
+   */
+  this.keys = function () {
+    return map.keys();
+  };
+
+  /**
+   * Delete the register at the given key.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedRegisterMap#delete
+   * @param {module:akkaserverless.Serializable} key The key to delete.
+   * @return {module:akkaserverless.replicatedentity.ReplicatedRegisterMap} This register map.
+   */
+  this.delete = function (key) {
+    map.delete(key);
+    return this;
+  };
+
+  /**
+   * Clear all registers from this register map.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedRegisterMap#clear
+   * @return {module:akkaserverless.replicatedentity.ReplicatedRegisterMap} This register map.
+   */
+  this.clear = function () {
+    map.clear();
+    return this;
+  };
+
+  this.getAndResetDelta = function (initial) {
+    return map.getAndResetDelta(initial);
+  };
+
+  this.applyDelta = function (delta, anySupport, createForDelta) {
+    map.applyDelta(delta, anySupport, createForDelta);
+  };
+
+  this.toString = function () {
+    return (
+      'ReplicatedRegisterMap(' +
+      Array.from(map.entries())
+        .map(([key, register]) => key + ' -> ' + register.value)
+        .join(', ') +
+      ')'
+    );
+  };
+}
+
+module.exports = ReplicatedRegisterMap;

--- a/sdk/src/replicated-data/register.js
+++ b/sdk/src/replicated-data/register.js
@@ -74,7 +74,7 @@ function ReplicatedRegister(
   });
 
   /**
-   * Set the the value using a custom clock.
+   * Set the value using a custom clock.
    *
    * @function module:akkaserverless.replicatedentity.ReplicatedRegister#setWithClock
    * @param {module:akkaserverless.Serializable} value The value to set.

--- a/sdk/src/replicated-data/set.js
+++ b/sdk/src/replicated-data/set.js
@@ -81,6 +81,16 @@ function ReplicatedSet() {
   };
 
   /**
+   * Get a copy of the current elements as a Set.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedSet#elements
+   * @return {Set<module:akkaserverless.Serializable>}
+   */
+  this.elements = function () {
+    return new Set(currentValue.values());
+  };
+
+  /**
    * Add an element to this set.
    *
    * @function module:akkaserverless.replicatedentity.ReplicatedSet#add
@@ -97,6 +107,20 @@ function ReplicatedSet() {
         delta.added.set(comparable, serializedElement);
       }
       currentValue.set(comparable, element);
+    }
+    return this;
+  };
+
+  /**
+   * Add multiple elements to this set.
+   *
+   * @function module:akkaserverless.replicatedentity.ReplicatedSet#addAll
+   * @param {Iterator<module:akkaserverless.Serializable>} elements The elements to add.
+   * @return {module:akkaserverless.replicatedentity.ReplicatedSet} This set.
+   */
+  this.addAll = function (elements) {
+    for (const element of elements) {
+      this.add(element);
     }
     return this;
   };

--- a/sdk/src/replicated-entity.js
+++ b/sdk/src/replicated-entity.js
@@ -219,6 +219,8 @@ module.exports = {
   ReplicatedSet: replicatedData.ReplicatedSet,
   ReplicatedRegister: replicatedData.ReplicatedRegister,
   ReplicatedMap: replicatedData.ReplicatedMap,
+  ReplicatedCounterMap: replicatedData.ReplicatedCounterMap,
+  ReplicatedRegisterMap: replicatedData.ReplicatedRegisterMap,
   Vote: replicatedData.Vote,
   Clocks: replicatedData.Clocks,
 };

--- a/sdk/src/replicated-entity.js
+++ b/sdk/src/replicated-entity.js
@@ -221,6 +221,7 @@ module.exports = {
   ReplicatedMap: replicatedData.ReplicatedMap,
   ReplicatedCounterMap: replicatedData.ReplicatedCounterMap,
   ReplicatedRegisterMap: replicatedData.ReplicatedRegisterMap,
+  ReplicatedMultiMap: replicatedData.ReplicatedMultiMap,
   Vote: replicatedData.Vote,
   Clocks: replicatedData.Clocks,
 };

--- a/sdk/test/replicated-data/counter-map-test.js
+++ b/sdk/test/replicated-data/counter-map-test.js
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const should = require('chai').should();
+const ReplicatedData = require('../../src/replicated-data');
+const ReplicatedCounterMap = require('../../src/replicated-data/counter-map');
+const ReplicatedMap = require('../../src/replicated-data/map');
+const protobuf = require('protobufjs');
+const protobufHelper = require('../../src/protobuf-helper');
+const AnySupport = require('../../src/protobuf-any');
+
+const ReplicatedEntityDelta =
+  protobufHelper.moduleRoot.akkaserverless.component.replicatedentity
+    .ReplicatedEntityDelta;
+
+const root = new protobuf.Root();
+const anySupport = new AnySupport(root);
+
+function roundTripDelta(delta) {
+  return ReplicatedEntityDelta.decode(
+    ReplicatedEntityDelta.encode(delta).finish(),
+  );
+}
+
+function toAny(value) {
+  return AnySupport.serialize(value, true, true);
+}
+
+function fromAnys(values) {
+  return values.map((any) => anySupport.deserialize(any));
+}
+
+function deltaEntries(entries) {
+  return entries.map((entry) => {
+    return {
+      key: anySupport.deserialize(entry.key),
+      delta: entry.delta.counter.change.toNumber(),
+    };
+  });
+}
+
+function counterDelta(key, value) {
+  return { key: toAny(key), delta: { counter: { change: value } } };
+}
+
+describe('ReplicatedCounterMap', () => {
+  it('should have no elements when instantiated', () => {
+    const counterMap = new ReplicatedCounterMap();
+    counterMap.size.should.equal(0);
+    should.equal(counterMap.getAndResetDelta(), null);
+  });
+
+  it('should reflect an initial delta', () => {
+    const counterMap = new ReplicatedCounterMap();
+    counterMap.applyDelta(
+      roundTripDelta({
+        replicatedMap: {
+          added: [counterDelta('one', 1), counterDelta('two', 2)],
+        },
+      }),
+      anySupport,
+      ReplicatedData.createForDelta,
+    );
+    Array.from(counterMap.keys()).should.have.members(['one', 'two']);
+    counterMap.get('one').should.equal(1);
+    counterMap.get('two').should.equal(2);
+    counterMap.getLong('one').toNumber().should.equal(1);
+    counterMap.getLong('two').toNumber().should.equal(2);
+    should.equal(counterMap.getAndResetDelta(), null);
+  });
+
+  it('should wrap an initial ReplicatedMap', () => {
+    const map = new ReplicatedMap();
+    map.applyDelta(
+      roundTripDelta({
+        replicatedMap: {
+          added: [counterDelta('one', 3), counterDelta('two', 4)],
+        },
+      }),
+      anySupport,
+      ReplicatedData.createForDelta,
+    );
+    const counterMap = new ReplicatedCounterMap(map);
+    Array.from(counterMap.keys()).should.have.members(['one', 'two']);
+    counterMap.get('one').should.equal(3);
+    counterMap.get('two').should.equal(4);
+    should.equal(counterMap.getAndResetDelta(), null);
+  });
+
+  it('should generate an added delta', () => {
+    const counterMap = new ReplicatedCounterMap();
+    counterMap.increment('one', 1);
+    counterMap.has('one').should.be.true;
+    counterMap.size.should.equal(1);
+
+    const delta = roundTripDelta(counterMap.getAndResetDelta());
+    deltaEntries(delta.replicatedMap.added).should.have.deep.members([
+      { key: 'one', delta: 1 },
+    ]);
+    delta.replicatedMap.updated.should.be.empty;
+    delta.replicatedMap.removed.should.be.empty;
+    delta.replicatedMap.cleared.should.be.false;
+  });
+
+  it('should generate a removed delta', () => {
+    const counterMap = new ReplicatedCounterMap();
+    counterMap.increment('one', 1);
+    counterMap.increment('two', 2);
+    counterMap.getAndResetDelta();
+    counterMap.delete('one');
+    counterMap.size.should.equal(1);
+    counterMap.has('one').should.be.false;
+    counterMap.has('two').should.be.true;
+
+    const delta = roundTripDelta(counterMap.getAndResetDelta());
+    fromAnys(delta.replicatedMap.removed).should.have.members(['one']);
+    delta.replicatedMap.added.should.be.empty;
+    delta.replicatedMap.updated.should.be.empty;
+    delta.replicatedMap.cleared.should.be.false;
+  });
+
+  it('should generate an updated delta', () => {
+    const counterMap = new ReplicatedCounterMap();
+    counterMap.increment('one', 1);
+    counterMap.getAndResetDelta();
+    counterMap.increment('one', 42);
+
+    const delta = roundTripDelta(counterMap.getAndResetDelta());
+    deltaEntries(delta.replicatedMap.updated).should.have.deep.members([
+      { key: 'one', delta: 42 },
+    ]);
+    delta.replicatedMap.added.should.be.empty;
+    delta.replicatedMap.removed.should.be.empty;
+    delta.replicatedMap.cleared.should.be.false;
+  });
+
+  it('should generate a cleared delta', () => {
+    const counterMap = new ReplicatedCounterMap();
+    counterMap.increment('one', 1);
+    counterMap.increment('two', 2);
+    counterMap.getAndResetDelta();
+    counterMap.clear();
+    counterMap.size.should.equal(0);
+
+    const delta = roundTripDelta(counterMap.getAndResetDelta());
+    delta.replicatedMap.cleared.should.be.true;
+    delta.replicatedMap.added.should.be.empty;
+    delta.replicatedMap.updated.should.be.empty;
+    delta.replicatedMap.removed.should.be.empty;
+  });
+});

--- a/sdk/test/replicated-data/map-test.js
+++ b/sdk/test/replicated-data/map-test.js
@@ -161,17 +161,6 @@ describe('ReplicatedMap', () => {
     should.equal(map.getAndResetDelta(), null);
   });
 
-  it('should generate a clear delta when everything is removed', () => {
-    const map = new ReplicatedMap()
-      .set('one', new replicatedData.ReplicatedCounter())
-      .set('two', new replicatedData.ReplicatedCounter());
-    map.getAndResetDelta();
-    map.delete('one').delete('two').size.should.equal(0);
-    const delta = roundTripDelta(map.getAndResetDelta());
-    delta.replicatedMap.cleared.should.be.true;
-    should.equal(map.getAndResetDelta(), null);
-  });
-
   it('should not generate a delta when an added element is removed', () => {
     const map = new ReplicatedMap().set(
       'one',

--- a/sdk/test/replicated-data/multi-map-test.js
+++ b/sdk/test/replicated-data/multi-map-test.js
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const should = require('chai').should();
+const ReplicatedMultiMap = require('../../src/replicated-data/multi-map');
+const path = require('path');
+const protobuf = require('protobufjs');
+const protobufHelper = require('../../src/protobuf-helper');
+const AnySupport = require('../../src/protobuf-any');
+
+const ReplicatedEntityDelta =
+  protobufHelper.moduleRoot.akkaserverless.component.replicatedentity
+    .ReplicatedEntityDelta;
+
+const root = new protobuf.Root();
+root.loadSync(path.join(__dirname, '..', 'example.proto'));
+root.resolveAll();
+const Example = root.lookupType('com.example.Example');
+const anySupport = new AnySupport(root);
+
+function roundTripDelta(delta) {
+  return ReplicatedEntityDelta.decode(
+    ReplicatedEntityDelta.encode(delta).finish(),
+  );
+}
+
+function toAny(value) {
+  return AnySupport.serialize(value, true, true);
+}
+
+function fromAnys(values) {
+  return values.map((any) => anySupport.deserialize(any));
+}
+
+function deltaEntries(entries) {
+  return entries.map((entry) => {
+    return {
+      key: anySupport.deserialize(entry.key),
+      delta: {
+        removed: fromAnys(entry.delta.removed),
+        added: fromAnys(entry.delta.added),
+      },
+    };
+  });
+}
+
+function valuesDelta(key, delta) {
+  return {
+    key: toAny(key),
+    delta: {
+      removed: (delta.removed || []).map(toAny),
+      added: (delta.added || []).map(toAny),
+    },
+  };
+}
+
+describe('ReplicatedMultiMap', () => {
+  it('should have no elements when instantiated', () => {
+    const multiMap = new ReplicatedMultiMap();
+    multiMap.size.should.equal(0);
+    should.equal(multiMap.getAndResetDelta(), null);
+  });
+
+  it('should reflect an initial delta', () => {
+    const multiMap = new ReplicatedMultiMap();
+    multiMap.applyDelta(
+      roundTripDelta({
+        replicatedMultiMap: {
+          updated: [
+            valuesDelta('key1', { added: ['value1'] }),
+            valuesDelta('key2', { added: ['value2', 'value3'] }),
+          ],
+        },
+      }),
+      anySupport,
+    );
+    Array.from(multiMap.keys()).should.have.members(['key1', 'key2']);
+    Array.from(multiMap.get('key1')).should.have.members(['value1']);
+    Array.from(multiMap.get('key2')).should.have.members(['value2', 'value3']);
+    should.equal(multiMap.getAndResetDelta(), null);
+  });
+
+  it('should generate a delta with added entries', () => {
+    const multiMap = new ReplicatedMultiMap();
+    multiMap.put('key1', 'value1');
+    multiMap.putAll('key2', ['value2', 'value3']);
+
+    multiMap.keysSize.should.equal(2);
+    multiMap.size.should.equal(3);
+    multiMap.has('key1').should.be.true;
+    multiMap.hasValue('key1', 'value1').should.be.true;
+    Array.from(multiMap.get('key1')).should.have.members(['value1']);
+    multiMap.has('key2').should.be.true;
+    multiMap.hasValue('key2', 'value2').should.be.true;
+    multiMap.hasValue('key2', 'value3').should.be.true;
+    Array.from(multiMap.get('key2')).should.have.members(['value2', 'value3']);
+
+    const delta = roundTripDelta(multiMap.getAndResetDelta());
+    deltaEntries(delta.replicatedMultiMap.updated).should.have.deep.members([
+      { key: 'key1', delta: { removed: [], added: ['value1'] } },
+      { key: 'key2', delta: { removed: [], added: ['value2', 'value3'] } },
+    ]);
+    delta.replicatedMultiMap.removed.should.be.empty;
+    delta.replicatedMultiMap.cleared.should.be.false;
+  });
+
+  it('should generate a delta with removed entries', () => {
+    const multiMap = new ReplicatedMultiMap();
+    multiMap.put('key1', 'value1');
+    multiMap.putAll('key2', ['value2', 'value3']);
+    multiMap.putAll('key3', ['value4', 'value5', 'value6']);
+    multiMap.keysSize.should.equal(3);
+    multiMap.size.should.equal(6);
+    multiMap.getAndResetDelta();
+
+    multiMap.delete('key2', 'value3');
+    multiMap.deleteAll('key3');
+    multiMap.keysSize.should.equal(2);
+    multiMap.size.should.equal(2);
+    Array.from(multiMap.keys()).should.have.members(['key1', 'key2']);
+    Array.from(multiMap.get('key1')).should.have.members(['value1']);
+    Array.from(multiMap.get('key2')).should.have.members(['value2']);
+
+    const delta = roundTripDelta(multiMap.getAndResetDelta());
+    fromAnys(delta.replicatedMultiMap.removed).should.have.members(['key3']);
+    deltaEntries(delta.replicatedMultiMap.updated).should.have.deep.members([
+      { key: 'key2', delta: { removed: ['value3'], added: [] } },
+    ]);
+    delta.replicatedMultiMap.cleared.should.be.false;
+  });
+
+  it('should generate a delta with updated entries', () => {
+    const multiMap = new ReplicatedMultiMap();
+    multiMap.put('key1', 'value1');
+    multiMap.putAll('key2', ['value2', 'value3']);
+    multiMap.keysSize.should.equal(2);
+    multiMap.size.should.equal(3);
+    multiMap.getAndResetDelta();
+
+    multiMap.put('key1', 'value2');
+    multiMap.delete('key2', 'value2');
+    multiMap.put('key2', 'value4');
+    multiMap.putAll('key3', ['value5', 'value6', 'value7']);
+    multiMap.keysSize.should.equal(3);
+    multiMap.size.should.equal(7);
+    Array.from(multiMap.keys()).should.have.members(['key1', 'key2', 'key3']);
+    Array.from(multiMap.get('key1')).should.have.members(['value1', 'value2']);
+    Array.from(multiMap.get('key2')).should.have.members(['value3', 'value4']);
+    Array.from(multiMap.get('key3')).should.have.members([
+      'value5',
+      'value6',
+      'value7',
+    ]);
+
+    const delta = roundTripDelta(multiMap.getAndResetDelta());
+    deltaEntries(delta.replicatedMultiMap.updated).should.have.deep.members([
+      { key: 'key1', delta: { removed: [], added: ['value2'] } },
+      { key: 'key2', delta: { removed: ['value2'], added: ['value4'] } },
+      {
+        key: 'key3',
+        delta: { removed: [], added: ['value5', 'value6', 'value7'] },
+      },
+    ]);
+    delta.replicatedMultiMap.removed.should.be.empty;
+    delta.replicatedMultiMap.cleared.should.be.false;
+  });
+
+  it('should generate a delta with cleared entries', () => {
+    const multiMap = new ReplicatedMultiMap();
+    multiMap.put('key1', 'value1');
+    multiMap.putAll('key2', ['value2', 'value3']);
+    multiMap.keysSize.should.equal(2);
+    multiMap.size.should.equal(3);
+    multiMap.getAndResetDelta();
+
+    multiMap.clear();
+    multiMap.keysSize.should.equal(0);
+    multiMap.size.should.equal(0);
+
+    const delta = roundTripDelta(multiMap.getAndResetDelta());
+    delta.replicatedMultiMap.cleared.should.be.true;
+    delta.replicatedMultiMap.updated.should.be.empty;
+    delta.replicatedMultiMap.removed.should.be.empty;
+  });
+
+  it('should reflect a delta with added entries', () => {
+    const multiMap = new ReplicatedMultiMap();
+    multiMap.put('key1', 'value1');
+    multiMap.getAndResetDelta();
+
+    multiMap.applyDelta(
+      roundTripDelta({
+        replicatedMultiMap: {
+          updated: [
+            valuesDelta('key2', { added: ['value2'] }),
+            valuesDelta('key3', { added: ['value3', 'value4'] }),
+          ],
+        },
+      }),
+      anySupport,
+    );
+    multiMap.keysSize.should.equal(3);
+    multiMap.size.should.equal(4);
+    Array.from(multiMap.keys()).should.have.members(['key1', 'key2', 'key3']);
+    Array.from(multiMap.get('key1')).should.have.members(['value1']);
+    Array.from(multiMap.get('key2')).should.have.members(['value2']);
+    Array.from(multiMap.get('key3')).should.have.members(['value3', 'value4']);
+    should.equal(multiMap.getAndResetDelta(), null);
+  });
+
+  it('should reflect a delta with removed entries', () => {
+    const multiMap = new ReplicatedMultiMap();
+    multiMap.put('key1', 'value1');
+    multiMap.putAll('key2', ['value2', 'value3']);
+    multiMap.putAll('key3', ['value4', 'value5', 'value6']);
+    multiMap.getAndResetDelta();
+
+    multiMap.applyDelta(
+      roundTripDelta({
+        replicatedMultiMap: {
+          removed: [toAny('key3')],
+          updated: [valuesDelta('key2', { removed: ['value3'] })],
+        },
+      }),
+      anySupport,
+    );
+    multiMap.keysSize.should.equal(2);
+    multiMap.size.should.equal(2);
+    Array.from(multiMap.keys()).should.have.members(['key1', 'key2']);
+    Array.from(multiMap.get('key1')).should.have.members(['value1']);
+    Array.from(multiMap.get('key2')).should.have.members(['value2']);
+    should.equal(multiMap.getAndResetDelta(), null);
+  });
+
+  it('should reflect a delta with cleared entries', () => {
+    const multiMap = new ReplicatedMultiMap();
+    multiMap.put('key1', 'value1');
+    multiMap.putAll('key2', ['value2', 'value3']);
+    multiMap.keysSize.should.equal(2);
+    multiMap.size.should.equal(3);
+    multiMap.getAndResetDelta();
+
+    multiMap.applyDelta(
+      roundTripDelta({
+        replicatedMultiMap: {
+          cleared: true,
+        },
+      }),
+      anySupport,
+    );
+    multiMap.keysSize.should.equal(0);
+    multiMap.size.should.equal(0);
+    should.equal(multiMap.getAndResetDelta(), null);
+  });
+
+  it('should support protobuf messages for keys and values', () => {
+    const multiMap = new ReplicatedMultiMap();
+    multiMap.put(
+      Example.create({ field1: 'key1' }),
+      Example.create({ field1: 'value1' }),
+    );
+    multiMap.put(
+      Example.create({ field1: 'key2' }),
+      Example.create({ field1: 'value2' }),
+    );
+    multiMap.putAll(Example.create({ field1: 'key3' }), [
+      Example.create({ field1: 'value3' }),
+      Example.create({ field1: 'value4' }),
+    ]);
+
+    const delta1 = roundTripDelta(multiMap.getAndResetDelta());
+    deltaEntries(delta1.replicatedMultiMap.updated).should.have.deep.members([
+      {
+        key: Example.create({ field1: 'key1' }),
+        delta: { removed: [], added: [Example.create({ field1: 'value1' })] },
+      },
+      {
+        key: Example.create({ field1: 'key2' }),
+        delta: { removed: [], added: [Example.create({ field1: 'value2' })] },
+      },
+      {
+        key: Example.create({ field1: 'key3' }),
+        delta: {
+          removed: [],
+          added: [
+            Example.create({ field1: 'value3' }),
+            Example.create({ field1: 'value4' }),
+          ],
+        },
+      },
+    ]);
+    delta1.replicatedMultiMap.removed.should.be.empty;
+    delta1.replicatedMultiMap.cleared.should.be.false;
+
+    multiMap.delete(
+      Example.create({ field1: 'key3' }),
+      Example.create({ field1: 'value4' }),
+    );
+    multiMap.deleteAll(Example.create({ field1: 'key2' }));
+    multiMap.keysSize.should.equal(2);
+    multiMap.size.should.equal(2);
+
+    const delta2 = roundTripDelta(multiMap.getAndResetDelta());
+    fromAnys(delta2.replicatedMultiMap.removed).should.have.deep.members([
+      Example.create({ field1: 'key2' }),
+    ]);
+    deltaEntries(delta2.replicatedMultiMap.updated).should.have.deep.members([
+      {
+        key: Example.create({ field1: 'key3' }),
+        delta: { removed: [Example.create({ field1: 'value4' })], added: [] },
+      },
+    ]);
+    delta2.replicatedMultiMap.cleared.should.be.false;
+  });
+
+  it('should support json objects for keys and values', () => {
+    const multiMap = new ReplicatedMultiMap();
+    multiMap.put({ foo: 'key1' }, { foo: 'value1' });
+    multiMap.put({ foo: 'key2' }, { foo: 'value2' });
+    multiMap.putAll({ foo: 'key3' }, [{ foo: 'value3' }, { foo: 'value4' }]);
+
+    const delta1 = roundTripDelta(multiMap.getAndResetDelta());
+    deltaEntries(delta1.replicatedMultiMap.updated).should.have.deep.members([
+      {
+        key: { foo: 'key1' },
+        delta: { removed: [], added: [{ foo: 'value1' }] },
+      },
+      {
+        key: { foo: 'key2' },
+        delta: { removed: [], added: [{ foo: 'value2' }] },
+      },
+      {
+        key: { foo: 'key3' },
+        delta: { removed: [], added: [{ foo: 'value3' }, { foo: 'value4' }] },
+      },
+    ]);
+    delta1.replicatedMultiMap.removed.should.be.empty;
+    delta1.replicatedMultiMap.cleared.should.be.false;
+
+    multiMap.delete({ foo: 'key3' }, { foo: 'value4' });
+    multiMap.deleteAll({ foo: 'key2' });
+    multiMap.keysSize.should.equal(2);
+    multiMap.size.should.equal(2);
+
+    const delta2 = roundTripDelta(multiMap.getAndResetDelta());
+    fromAnys(delta2.replicatedMultiMap.removed).should.have.deep.members([
+      { foo: 'key2' },
+    ]);
+    deltaEntries(delta2.replicatedMultiMap.updated).should.have.deep.members([
+      {
+        key: { foo: 'key3' },
+        delta: { removed: [{ foo: 'value4' }], added: [] },
+      },
+    ]);
+    delta2.replicatedMultiMap.cleared.should.be.false;
+  });
+});

--- a/sdk/test/replicated-data/register-map-test.js
+++ b/sdk/test/replicated-data/register-map-test.js
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const should = require('chai').should();
+const ReplicatedData = require('../../src/replicated-data');
+const ReplicatedRegisterMap = require('../../src/replicated-data/register-map');
+const ReplicatedMap = require('../../src/replicated-data/map');
+const path = require('path');
+const protobuf = require('protobufjs');
+const protobufHelper = require('../../src/protobuf-helper');
+const AnySupport = require('../../src/protobuf-any');
+
+const ReplicatedEntityDelta =
+  protobufHelper.moduleRoot.akkaserverless.component.replicatedentity
+    .ReplicatedEntityDelta;
+
+const root = new protobuf.Root();
+root.loadSync(path.join(__dirname, '..', 'example.proto'));
+root.resolveAll();
+const Example = root.lookupType('com.example.Example');
+const anySupport = new AnySupport(root);
+
+function roundTripDelta(delta) {
+  return ReplicatedEntityDelta.decode(
+    ReplicatedEntityDelta.encode(delta).finish(),
+  );
+}
+
+function toAny(value) {
+  return AnySupport.serialize(value, true, true);
+}
+
+function fromAnys(values) {
+  return values.map((any) => anySupport.deserialize(any));
+}
+
+function deltaEntries(entries) {
+  return entries.map((entry) => {
+    return {
+      key: anySupport.deserialize(entry.key),
+      delta: anySupport.deserialize(entry.delta.register.value),
+    };
+  });
+}
+
+function registerDelta(key, value) {
+  return { key: toAny(key), delta: { register: { value: toAny(value) } } };
+}
+
+describe('ReplicatedRegisterMap', () => {
+  it('should have no elements when instantiated', () => {
+    const registerMap = new ReplicatedRegisterMap();
+    registerMap.size.should.equal(0);
+    should.equal(registerMap.getAndResetDelta(), null);
+  });
+
+  it('should reflect an initial delta', () => {
+    const registerMap = new ReplicatedRegisterMap();
+    registerMap.applyDelta(
+      roundTripDelta({
+        replicatedMap: {
+          added: [
+            registerDelta('one', 1),
+            registerDelta('two', 'foo'),
+            registerDelta('three', Example.create({ field1: 'bar' })),
+          ],
+        },
+      }),
+      anySupport,
+      ReplicatedData.createForDelta,
+    );
+    Array.from(registerMap.keys()).should.have.members(['one', 'two', 'three']);
+    registerMap.get('one').should.equal(1);
+    registerMap.get('two').should.equal('foo');
+    registerMap.get('three').field1.should.equal('bar');
+    should.equal(registerMap.getAndResetDelta(), null);
+  });
+
+  it('should wrap an initial ReplicatedMap', () => {
+    const map = new ReplicatedMap();
+    map.applyDelta(
+      roundTripDelta({
+        replicatedMap: {
+          added: [
+            registerDelta('one', 1),
+            registerDelta('two', 'foo'),
+            registerDelta('three', Example.create({ field1: 'bar' })),
+          ],
+        },
+      }),
+      anySupport,
+      ReplicatedData.createForDelta,
+    );
+    const registerMap = new ReplicatedRegisterMap(map);
+    Array.from(registerMap.keys()).should.have.members(['one', 'two', 'three']);
+    registerMap.get('one').should.equal(1);
+    registerMap.get('two').should.equal('foo');
+    registerMap.get('three').field1.should.equal('bar');
+    should.equal(registerMap.getAndResetDelta(), null);
+  });
+
+  it('should generate an added delta', () => {
+    const registerMap = new ReplicatedRegisterMap();
+    registerMap.set('one', 1);
+    registerMap.has('one').should.be.true;
+    registerMap.size.should.equal(1);
+
+    const delta = roundTripDelta(registerMap.getAndResetDelta());
+    deltaEntries(delta.replicatedMap.added).should.have.deep.members([
+      { key: 'one', delta: 1 },
+    ]);
+    delta.replicatedMap.updated.should.be.empty;
+    delta.replicatedMap.removed.should.be.empty;
+    delta.replicatedMap.cleared.should.be.false;
+  });
+
+  it('should generate a removed delta', () => {
+    const registerMap = new ReplicatedRegisterMap();
+    registerMap.set('one', 1);
+    registerMap.set('two', 'foo');
+    registerMap.getAndResetDelta();
+    registerMap.delete('one');
+    registerMap.size.should.equal(1);
+    registerMap.has('one').should.be.false;
+    registerMap.has('two').should.be.true;
+
+    const delta = roundTripDelta(registerMap.getAndResetDelta());
+    fromAnys(delta.replicatedMap.removed).should.have.members(['one']);
+    delta.replicatedMap.added.should.be.empty;
+    delta.replicatedMap.updated.should.be.empty;
+    delta.replicatedMap.cleared.should.be.false;
+  });
+
+  it('should generate an updated delta', () => {
+    const registerMap = new ReplicatedRegisterMap();
+    registerMap.set('one', 42);
+    registerMap.getAndResetDelta();
+    registerMap.set('one', 'forty-two');
+
+    const delta = roundTripDelta(registerMap.getAndResetDelta());
+    deltaEntries(delta.replicatedMap.updated).should.have.deep.members([
+      { key: 'one', delta: 'forty-two' },
+    ]);
+    delta.replicatedMap.added.should.be.empty;
+    delta.replicatedMap.removed.should.be.empty;
+    delta.replicatedMap.cleared.should.be.false;
+  });
+
+  it('should generate a cleared delta', () => {
+    const registerMap = new ReplicatedRegisterMap();
+    registerMap.set('one', 1);
+    registerMap.set('two', 2);
+    registerMap.getAndResetDelta();
+    registerMap.clear();
+    registerMap.size.should.equal(0);
+
+    const delta = roundTripDelta(registerMap.getAndResetDelta());
+    delta.replicatedMap.cleared.should.be.true;
+    delta.replicatedMap.added.should.be.empty;
+    delta.replicatedMap.updated.should.be.empty;
+    delta.replicatedMap.removed.should.be.empty;
+  });
+});


### PR DESCRIPTION
Refs https://github.com/lightbend/akkaserverless-java-sdk/issues/48. Add specialised replicated maps for counters and registers, similar to Java SDK. Test with the new TCK tests from https://github.com/lightbend/akkaserverless-framework/pull/802 (needs to be published first, draft PR here). And support the new replicated maps from https://github.com/lightbend/akkaserverless-framework/pull/803. Refs https://github.com/lightbend/akkaserverless-java-sdk/issues/49.