### PR TITLE
enhancement: show fuller proto files

### DIFF
--- a/docs/src/modules/javascript/pages/views.adoc
+++ b/docs/src/modules/javascript/pages/views.adoc
@@ -30,7 +30,7 @@ This example assumes the following `customer` state is defined in a `customer_do
 
 [source,proto,indent=0]
 ----
-include::example$js-customer-registry/customer_domain.proto[tag=domain]
+include::example$js-customer-registry/customer_domain.proto[tag=declarations;domain]
 ----
 
 === Define the View service descriptor
@@ -44,7 +44,7 @@ To get a view of multiple customers by their name, define the View as a `service
 
 [source,proto,indent=0]
 ----
-include::example$js-customer-registry/customer_view.proto[tag=service]
+include::example$js-customer-registry/customer_view.proto[tag=declarations;service]
 ----
 
 <1> The `UpdateCustomer` method defines how Akka Serverless will update the view.
@@ -103,7 +103,7 @@ will update the View when a name changes:
 
 [source,proto,indent=0]
 ----
-include::example$js-customer-registry/customer_domain.proto[tag=events]
+include::example$js-customer-registry/customer_domain.proto[tag=declarations;events]
 ----
 
 === Define the View descriptor
@@ -119,7 +119,7 @@ The following example `customer_view.proto` file defines a View to consume the `
 
 [source,proto,indent=0]
 ----
-include::example$js-customer-registry/customer_view.proto[tag=service-event-sourced]
+include::example$js-customer-registry/customer_view.proto[tag=declarations;service-event-sourced]
 ----
 
 <1> Define an update method for each event.
@@ -173,7 +173,7 @@ The source of a View can be an eventing topic. You define it in the same way as 
 
 [source,proto,indent=0]
 ----
-include::example$js-customer-registry/customer_view.proto[tag=service-topic]
+include::example$js-customer-registry/customer_view.proto[tag=declarations;service-topic]
 ----
 
 <1> This is the only difference from <<event-sourced-entity>>.
@@ -190,7 +190,7 @@ To obtain different results than shown in the examples above, you can transform 
 Instead of using `SELECT *` you can define the columns to use in the response message:
 [source,proto,indent=0]
 ----
-include::example$js-customer-registry/customer_view.proto[tag=summary]
+include::example$js-customer-registry/customer_view.proto[tag=declarations;summary]
 ----
 
 Similarly, you can include values from the request message in the response, such as `:request_id`:

--- a/docs/src/modules/javascript/pages/views.adoc
+++ b/docs/src/modules/javascript/pages/views.adoc
@@ -30,7 +30,7 @@ This example assumes the following `customer` state is defined in a `customer_do
 
 [source,proto,indent=0]
 ----
-include::example$js-customer-registry/customer_domain.proto[tag=declarations;domain]
+include::example$js-customer-registry/customer_domain.proto[tags=declarations;domain]
 ----
 
 === Define the View service descriptor
@@ -44,7 +44,7 @@ To get a view of multiple customers by their name, define the View as a `service
 
 [source,proto,indent=0]
 ----
-include::example$js-customer-registry/customer_view.proto[tag=declarations;service]
+include::example$js-customer-registry/customer_view.proto[tags=declarations;service]
 ----
 
 <1> The `UpdateCustomer` method defines how Akka Serverless will update the view.
@@ -103,7 +103,7 @@ will update the View when a name changes:
 
 [source,proto,indent=0]
 ----
-include::example$js-customer-registry/customer_domain.proto[tag=declarations;events]
+include::example$js-customer-registry/customer_domain.proto[tags=declarations;events]
 ----
 
 === Define the View descriptor
@@ -119,7 +119,7 @@ The following example `customer_view.proto` file defines a View to consume the `
 
 [source,proto,indent=0]
 ----
-include::example$js-customer-registry/customer_view.proto[tag=declarations;service-event-sourced]
+include::example$js-customer-registry/customer_view.proto[tags=declarations;service-event-sourced]
 ----
 
 <1> Define an update method for each event.
@@ -163,7 +163,7 @@ Invoke the `addComponent` function to register the view with the service. For ex
 .index.js
 [source,js,indent=0]
 ----
-include::example$js-customer-registry/index.js[tag=register-event-sourced]
+include::example$js-customer-registry/index.js[tags=register-event-sourced]
 ----
 
 [#topic-view]
@@ -173,7 +173,7 @@ The source of a View can be an eventing topic. You define it in the same way as 
 
 [source,proto,indent=0]
 ----
-include::example$js-customer-registry/customer_view.proto[tag=declarations;service-topic]
+include::example$js-customer-registry/customer_view.proto[tags=declarations;service-topic]
 ----
 
 <1> This is the only difference from <<event-sourced-entity>>.
@@ -190,7 +190,7 @@ To obtain different results than shown in the examples above, you can transform 
 Instead of using `SELECT *` you can define the columns to use in the response message:
 [source,proto,indent=0]
 ----
-include::example$js-customer-registry/customer_view.proto[tag=declarations;summary]
+include::example$js-customer-registry/customer_view.proto[tags=declarations;summary]
 ----
 
 Similarly, you can include values from the request message in the response, such as `:request_id`:

--- a/samples/js-customer-registry/customer_domain.proto
+++ b/samples/js-customer-registry/customer_domain.proto
@@ -16,6 +16,7 @@
 syntax = "proto3";
 
 package customer.domain;
+
 // end::declarations[]
 
 // tag::domain[]

--- a/samples/js-customer-registry/customer_domain.proto
+++ b/samples/js-customer-registry/customer_domain.proto
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// tag::declarations[]
 syntax = "proto3";
 
 package customer.domain;
+// end::declarations[]
 
 // tag::domain[]
 message CustomerState {

--- a/samples/js-customer-registry/customer_view.proto
+++ b/samples/js-customer-registry/customer_view.proto
@@ -19,6 +19,7 @@ package customer.view;
 
 import "customer_domain.proto";
 import "akkaserverless/annotations.proto";
+
 // end::declarations[]
 
 // tag::service[]

--- a/samples/js-customer-registry/customer_view.proto
+++ b/samples/js-customer-registry/customer_view.proto
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// tag::declarations[]
 syntax = "proto3";
 
 package customer.view;
 
 import "customer_domain.proto";
 import "akkaserverless/annotations.proto";
+// end::declarations[]
 
 // tag::service[]
 service CustomerByName {


### PR DESCRIPTION
Fixes issue #97. Note, I'm marking this as a draft because it involves both source code and doc and I am not able to build it locally on my machine to check it. 

I also did not add all of the proto file to each example because we are using the same proto file to illustrate all of the different types of views. Instead, I just added the declarations. Are these additions enough so that a user copying them from the doc could create their own views (of each different type)? 