### PR TITLE
fix: add type declarations for entity passivation strategy

### DIFF
--- a/samples/js-replicated-entity-example/replicated-entity-example.js
+++ b/samples/js-replicated-entity-example/replicated-entity-example.js
@@ -15,8 +15,8 @@
  */
 
 
-const ReplicatedEntity = require("@lightbend/akkaserverless-javascript-sdk").ReplicatedEntity;
-const ReplicatedData = require("@lightbend/akkaserverless-javascript-sdk").ReplicatedData;
+const ReplicatedEntity = require("@lightbend/akkaserverless-javascript-sdk").replicatedentity.ReplicatedEntity;
+const ReplicatedData = require("@lightbend/akkaserverless-javascript-sdk").replicatedentity.ReplicatedData;
 
 const entity = new ReplicatedEntity(
   "replicated_entity_example.proto",

--- a/sdk/index.js
+++ b/sdk/index.js
@@ -23,10 +23,7 @@
 module.exports.AkkaServerless = require('./src/akkaserverless').AkkaServerless;
 module.exports.EventSourcedEntity = require('./src/event-sourced-entity');
 module.exports.ValueEntity = require('./src/value-entity');
-module.exports.ReplicatedEntity =
-  require('./src/replicated-entity').ReplicatedEntity;
-module.exports.ReplicatedData =
-  require('./src/replicated-entity').ReplicatedData;
+module.exports.replicatedentity = require('./src/replicated-entity');
 module.exports.ReplicatedWriteConsistency =
   require('./src/akkaserverless').ReplicatedWriteConsistency;
 module.exports.Action = require('./src/action');

--- a/sdk/src/event-sourced-entity.js
+++ b/sdk/src/event-sourced-entity.js
@@ -90,6 +90,14 @@ const eventSourcedEntityServices = new EventSourcedEntityServices();
  * @property {boolean} [serializeFallbackToJson=false] Whether serialization should fallback to using JSON if an event
  * or snapshot can't be serialized as a protobuf.
  * @property {array<string>} [forwardHeaders=[]] request headers to be forwarded as metadata to the event sourced entity
+ * @property {module:akkaserverless.EventSourcedEntity~entityPassivationStrategy} [entityPassivationStrategy] Entity passivation strategy to use.
+ */
+
+/**
+ * Entity passivation strategy for an event sourced entity.
+ *
+ * @typedef module:akkaserverless.EventSourcedEntity~entityPassivationStrategy
+ * @property {number} [timeout] Passivation timeout (in milliseconds).
  */
 
 /**

--- a/sdk/src/replicated-entity.js
+++ b/sdk/src/replicated-entity.js
@@ -29,6 +29,14 @@ const replicatedEntityServices = new support.ReplicatedEntityServices();
  *
  * @typedef module:akkaserverless.replicatedentity.ReplicatedEntity~options
  * @property {array<string>} includeDirs The directories to include when looking up imported protobuf files.
+ * @property {module:akkaserverless.replicatedentity.ReplicatedEntity~entityPassivationStrategy} [entityPassivationStrategy] Entity passivation strategy to use.
+ */
+
+/**
+ * Entity passivation strategy for a replicated entity.
+ *
+ * @typedef module:akkaserverless.replicatedentity.ReplicatedEntity~entityPassivationStrategy
+ * @property {number} [timeout] Passivation timeout (in milliseconds).
  */
 
 /**
@@ -105,12 +113,12 @@ class ReplicatedEntity {
   /**
    * Create a Replicated Entity.
    *
-   * @param desc {string|string[]} The file name of a protobuf descriptor or set of descriptors containing the
+   * @param {string|string[]} desc The file name of a protobuf descriptor or set of descriptors containing the
    *                               Replicated Entity service.
-   * @param serviceName {string} The fully qualified name of the gRPC service that this Replicated Entity implements.
+   * @param {string} serviceName The fully qualified name of the gRPC service that this Replicated Entity implements.
    * @param {string} entityType The entity type name, used to namespace entities of different Replicated Data
    *                            types in the same service.
-   * @param options {module:akkaserverless.replicatedentity.ReplicatedEntity~options=} The options.
+   * @param {module:akkaserverless.replicatedentity.ReplicatedEntity~options=} options The options for this entity.
    */
   constructor(desc, serviceName, entityType, options) {
     this.options = {

--- a/sdk/src/value-entity.js
+++ b/sdk/src/value-entity.js
@@ -62,6 +62,14 @@ const valueEntityServices = new ValueEntityServices();
  * @property {boolean} [serializeFallbackToJson=false] Whether serialization should fallback to using JSON if the state
  * can't be serialized as a protobuf.
  * @property {array<string>} [forwardHeaders=[]] request headers to be forwarded as metadata to the value entity
+ * @property {module:akkaserverless.ValueEntity~entityPassivationStrategy} [entityPassivationStrategy] Entity passivation strategy to use.
+ */
+
+/**
+ * Entity passivation strategy for a value entity.
+ *
+ * @typedef module:akkaserverless.ValueEntity~entityPassivationStrategy
+ * @property {number} [timeout] Passivation timeout (in milliseconds).
  */
 
 /**

--- a/tck/replicated-entity.js
+++ b/tck/replicated-entity.js
@@ -15,8 +15,8 @@
  */
 
 const sdk = require('@lightbend/akkaserverless-javascript-sdk');
-const ReplicatedEntity = sdk.ReplicatedEntity;
-const ReplicatedData = sdk.ReplicatedData;
+const ReplicatedEntity = sdk.replicatedentity.ReplicatedEntity;
+const ReplicatedData = sdk.replicatedentity.ReplicatedData;
 const ReplicatedWriteConsistency = sdk.ReplicatedWriteConsistency;
 
 const tckModel = new ReplicatedEntity(


### PR DESCRIPTION
Reported that the `entityPassivationStrategy` was missing from the entity options.