### PR TITLE
doc: fix references to npm

### DIFF
--- a/codegen/js-gen-cli/src/it/resources/application.conf
+++ b/codegen/js-gen-cli/src/it/resources/application.conf
@@ -1,5 +1,5 @@
 akkaserverless-npm-js {
-    # By default, we assume the akkaserverless NPM JS project is checked out next to this repository
+    # By default, we assume the akkaserverless npm-js project is checked out next to this repository
     path = "../akkaserverless-npm-js"
 }
 

--- a/codegen/js-gen-cli/src/it/resources/scripts/setup.sh
+++ b/codegen/js-gen-cli/src/it/resources/scripts/setup.sh
@@ -11,7 +11,7 @@ mv package.json original-package.json
 node /home/scripts/disable-download-cli.js original-package.json > package.json
 cp /home/akkasls-codegen-js bin/akkasls-codegen-js.bin
 
-# Use NPM link to make this available within the container
+# Use npm link to make this available within the container
 npm install
 npm link
 popd

--- a/docs/src/modules/javascript/pages/developer-tools.adoc
+++ b/docs/src/modules/javascript/pages/developer-tools.adoc
@@ -1,6 +1,6 @@
 = Developer Tools
 
-The Javascript tooling is published to npm or yarn under the https://www.npmjs.com/org/lightbend[`@lightbend` organisation].
+The Javascript tooling is published to the npm registry under the https://www.npmjs.com/org/lightbend[`@lightbend` organisation].
 
 == Kickstart
 

--- a/docs/src/modules/javascript/pages/index.adoc
+++ b/docs/src/modules/javascript/pages/index.adoc
@@ -17,7 +17,7 @@ The following are required to develop services in JavaScript:
 
 Node:: Akka Serverless requires at least Node {minimum_node_version}. You will find links to download Node https://nodejs.org/dist/latest-v14.x/[here {tab-icon}, window="new"].
 
-Build tool:: Akka Serverless does not require any particular build tool, you can select your own but out-of-the-box experience is provided in conjunction with NPM and YARN.
+Build tool:: Akka Serverless does not require any particular build tool, you can select your own but out-of-the-box experience is provided in conjunction with npm and Yarn.
 
 Docker:: Akka Serverless requires https://docs.docker.com/get-docker/[Docker {tab-icon}, window="new"] {minimum_docker_version} for building your service images. Most popular build tools have plugins that assist in building Docker images.
 
@@ -25,7 +25,7 @@ Since Akka Serverless is based on gRPC, you need a protoc compiler to compile gR
 
 == Development project requirements
 
-The following examples show how to install the SDK to build your services with NPM or YARM. The code generation tools include an Akka Serverless xref:kickstart.adoc[code generation tools] that generates the recommended project structure, including a `package.json` file with the necessary references.
+The following examples show how to install the SDK to build your services with npm or Yarn. The code generation tools include an Akka Serverless xref:kickstart.adoc[code generation tools] that generates the recommended project structure, including a `package.json` file with the necessary references.
 
 NOTE: The code generation tools do more than just provide a starter project, after you modify a `.proto` file, they will generate code stubs for the elements you changed or added.
 

--- a/npm-js/README.md
+++ b/npm-js/README.md
@@ -1,6 +1,6 @@
 # akkaserverless-npm-js
 
-This repository provides the `create-akkasls-entity` tool to support Akka Serverless development with the NPM/JavaScript toolchain.
+This repository provides the `create-akkasls-entity` tool to support Akka Serverless development with the npm/JavaScript toolchain.
 
 Please navigate to each project's README to comprehend what is provided in detail.
 
@@ -12,6 +12,6 @@ See this project's [README](create-akkasls-entity/README.md) for more informatio
 
 ## akkasls-scripts
 
-This NPM module provides the default `build`, `package` and `deploy` scripts for an Akka Serverless codebase in a single managed package.
+This npm module provides the default `build`, `package` and `deploy` scripts for an Akka Serverless codebase in a single managed package.
 
 See this project's [README](akkasls-scripts/README.md) for more information.

--- a/npm-js/create-akkasls-entity/README.md
+++ b/npm-js/create-akkasls-entity/README.md
@@ -1,6 +1,6 @@
 # create-akkasls-entity
 
-This repository provides the `create-akkasls-entity` tool to support Akka Serverless development with the NPM/JavaScript toolchain.
+This repository provides the `create-akkasls-entity` tool to support Akka Serverless development with the npm/JavaScript toolchain.
 
 ## Usage
 
@@ -12,7 +12,7 @@ There are two templates available to select from:
 - `value-entity` (default); provides the starting point to develop a [Value Entity](https://docs.akkaserverless.dev/js-services/value-entity.html)
 - `event-sourced-entity`; provides the starting point to develop an [Event Sourced Entity](https://docs.akkaserverless.dev/js-services/eventsourced.html)
 
-To create the initial codebase for a new entity with NPM:
+To create the initial codebase for a new entity with npm:
 
 ```sh
 npx @lightbend/create-akkasls-entity my-entity --template value-entity

--- a/npm-js/create-akkasls-entity/template/base/README.md
+++ b/npm-js/create-akkasls-entity/template/base/README.md
@@ -99,5 +99,5 @@ You will need to update the `config.dockerImage` property in the `package.json` 
 
 Finally, you can use the [Akka Serverless Console](https://console.akkaserverless.com)
 to create a project and then deploy your service into the project either by using `npm run deploy`,
-through the `akkasls` CLI or via the web interface. When using `npm run deploy`, NPM will also
+through the `akkasls` CLI or via the web interface. When using `npm run deploy`, npm will also
 conveniently package and publish your docker image prior to deployment.

--- a/samples/js/js-eventsourced-shopping-cart/README.md
+++ b/samples/js/js-eventsourced-shopping-cart/README.md
@@ -107,5 +107,5 @@ You will need to update the `config.dockerImage` property in the `package.json` 
 
 Finally, you can use the [Akka Serverless Console](https://console.akkaserverless.com)
 to create a project and then deploy your service into the project either by using `npm run deploy`,
-through the `akkasls` CLI or via the web interface. When using `npm run deploy`, NPM will also
+through the `akkasls` CLI or via the web interface. When using `npm run deploy`, npm will also
 conveniently package and publish your docker image prior to deployment.

--- a/samples/js/js-valueentity-shopping-cart/README.md
+++ b/samples/js/js-valueentity-shopping-cart/README.md
@@ -110,5 +110,5 @@ for more information on how to make your docker image available to Akka Serverle
 
 Finally you can or use the [Akka Serverless Console](https://console.akkaserverless.com)
 to create a project and then deploy your service into the project either by using `npm run deploy`,
-through the `akkasls` CLI or via the web interface. When using `npm run deploy`, NPM will also
+through the `akkasls` CLI or via the web interface. When using `npm run deploy`, npm will also
 conveniently package and publish your docker image prior to deployment.

--- a/samples/js/valueentity-counter/README.md
+++ b/samples/js/valueentity-counter/README.md
@@ -107,5 +107,5 @@ for more information on how to make your docker image available to Akka Serverle
 
 Finally you can or use the [Akka Serverless Console](https://console.akkaserverless.com)
 to create a project and then deploy your service into the project either by using `npm run deploy`,
-through the `akkasls` CLI or via the web interface. When using `npm run deploy`, NPM will also
+through the `akkasls` CLI or via the web interface. When using `npm run deploy`, npm will also
 conveniently package and publish your docker image prior to deployment.

--- a/samples/ts/ts-valueentity-shopping-cart/README.md
+++ b/samples/ts/ts-valueentity-shopping-cart/README.md
@@ -110,5 +110,5 @@ for more information on how to make your docker image available to Akka Serverle
 
 Finally you can use the [Akka Serverless Console](https://console.akkaserverless.com)
 to create a project and then deploy your service into the project either by using `npm run deploy`,
-through the `akkasls` CLI or via the web interface. When using `npm run deploy`, NPM will also
+through the `akkasls` CLI or via the web interface. When using `npm run deploy`, npm will also
 conveniently package and publish your docker image prior to deployment.


### PR DESCRIPTION
Fix usage of `NPM`, which should not be capitalised. Also some `YARN` and `YARM`.