### PR TITLE
fix: graceful shutdown in docker builds

### DIFF
--- a/npm-js/create-akkasls-entity/template/base/Dockerfile
+++ b/npm-js/create-akkasls-entity/template/base/Dockerfile
@@ -44,4 +44,5 @@ USER node
 
 # Run
 EXPOSE 8080
-CMD ["npm", "start"]
+# Call node directly to get SIGTERM for graceful shutdown
+CMD ["node", "src/index.js"]

--- a/samples/js/js-customer-registry/Dockerfile
+++ b/samples/js/js-customer-registry/Dockerfile
@@ -16,4 +16,4 @@ WORKDIR /home/node/samples/js/js-customer-registry
 USER node
 ENV NODE_ENV production
 EXPOSE 8080
-CMD ["npm", "run", "start-no-prestart"]
+CMD ["node", "index.js"]

--- a/samples/js/js-customer-registry/package.json
+++ b/samples/js/js-customer-registry/package.json
@@ -24,7 +24,7 @@
   "//": "https://npm.community/t/npm-install-does-not-install-transitive-dependencies-of-local-dependency/2264",
   "dependencies": {
     "@grpc/proto-loader": "^0.1.0",
-    "@lightbend/akkaserverless-javascript-sdk": "file:../../../sdk",
+    "@lightbend/akkaserverless-javascript-sdk": "0.33.0",
     "google-protobuf": "^3.11.4",
     "grpc": "^1.24.9"
   },

--- a/samples/js/js-eventsourced-shopping-cart/Dockerfile
+++ b/samples/js/js-eventsourced-shopping-cart/Dockerfile
@@ -44,4 +44,5 @@ USER node
 
 # Run
 EXPOSE 8080
-CMD ["npm", "start"]
+# Call node directly to get SIGTERM for graceful shutdown
+CMD ["node", "src/index.js"]

--- a/samples/js/js-eventsourced-shopping-cart/package.json
+++ b/samples/js/js-eventsourced-shopping-cart/package.json
@@ -7,10 +7,10 @@
     "npm": ">=6.0.0"
   },
   "dependencies": {
-    "@lightbend/akkaserverless-javascript-sdk": "0.30.0"
+    "@lightbend/akkaserverless-javascript-sdk": "0.33.0"
   },
   "devDependencies": {
-    "@lightbend/akkasls-scripts": "0.30.0",
+    "@lightbend/akkasls-scripts": "0.33.0",
     "chai": "^4.3.3",
     "jsdoc": "^3.6.3",
     "mocha": "^8.3.1",

--- a/samples/js/js-replicated-entity-example/Dockerfile
+++ b/samples/js/js-replicated-entity-example/Dockerfile
@@ -16,4 +16,4 @@ WORKDIR /home/node/samples/js/js-replicated-entity-example
 USER node
 ENV NODE_ENV production
 EXPOSE 8080
-CMD ["npm", "run", "start-no-prestart"]
+CMD ["node", "index.js"]

--- a/samples/js/js-valueentity-shopping-cart/Dockerfile
+++ b/samples/js/js-valueentity-shopping-cart/Dockerfile
@@ -44,4 +44,5 @@ USER node
 
 # Run
 EXPOSE 8080
-CMD ["npm", "start"]
+# Call node directly to get SIGTERM for graceful shutdown
+CMD ["node", "src/index.js"]

--- a/samples/js/js-valueentity-shopping-cart/package.json
+++ b/samples/js/js-valueentity-shopping-cart/package.json
@@ -1,16 +1,16 @@
 {
   "name": "js-valueentity-shopping-cart",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "type": "module",
   "engines": {
     "node": ">=13.0.0",
     "npm": ">=6.0.0"
   },
   "dependencies": {
-    "@lightbend/akkaserverless-javascript-sdk": "0.30.0"
+    "@lightbend/akkaserverless-javascript-sdk": "0.33.0"
   },
   "devDependencies": {
-    "@lightbend/akkasls-scripts": "0.30.0",
+    "@lightbend/akkasls-scripts": "0.33.0",
     "chai": "^4.3.3",
     "jsdoc": "^3.6.3",
     "mocha": "^8.3.1",

--- a/samples/js/js-views-example/Dockerfile
+++ b/samples/js/js-views-example/Dockerfile
@@ -16,4 +16,4 @@ WORKDIR /home/node/samples/js/js-views-example
 USER node
 ENV NODE_ENV production
 EXPOSE 8080
-CMD ["npm", "run", "start-no-prestart"]
+CMD ["node", "index.js"]

--- a/samples/js/js-views-example/package.json
+++ b/samples/js/js-views-example/package.json
@@ -24,7 +24,7 @@
   "//": "https://npm.community/t/npm-install-does-not-install-transitive-dependencies-of-local-dependency/2264",
   "dependencies": {
     "@grpc/proto-loader": "^0.1.0",
-    "@lightbend/akkaserverless-javascript-sdk": "file:../../../sdk",
+    "@lightbend/akkaserverless-javascript-sdk": "0.33.0",
     "google-protobuf": "^3.11.4",
     "grpc": "^1.24.9"
   },

--- a/samples/js/valueentity-counter/Dockerfile
+++ b/samples/js/valueentity-counter/Dockerfile
@@ -44,4 +44,5 @@ USER node
 
 # Run
 EXPOSE 8080
-CMD ["npm", "start"]
+# Call node directly to get SIGTERM for graceful shutdown
+CMD ["node", "src/index.js"]

--- a/samples/js/valueentity-counter/package.json
+++ b/samples/js/valueentity-counter/package.json
@@ -7,10 +7,10 @@
     "npm": ">=6.0.0"
   },
   "dependencies": {
-    "@lightbend/akkaserverless-javascript-sdk": "0.30.0"
+    "@lightbend/akkaserverless-javascript-sdk": "0.33.0"
   },
   "devDependencies": {
-    "@lightbend/akkasls-scripts": "0.30.0",
+    "@lightbend/akkasls-scripts": "0.33.0",
     "chai": "^4.3.3",
     "jsdoc": "^3.6.3",
     "mocha": "^8.3.1",

--- a/samples/ts/ts-customer-registry/Dockerfile
+++ b/samples/ts/ts-customer-registry/Dockerfile
@@ -13,4 +13,4 @@ WORKDIR /home/node/samples/ts/ts-customer-registry
 USER node
 ENV NODE_ENV production
 EXPOSE 8080
-CMD ["npm", "run", "start-no-prestart"]
+CMD ["node", "dist/index.js"]

--- a/samples/ts/ts-eventsourced-shopping-cart/Dockerfile
+++ b/samples/ts/ts-eventsourced-shopping-cart/Dockerfile
@@ -44,4 +44,5 @@ USER node
 
 # Run
 EXPOSE 8080
-CMD ["npm", "start"]
+# Call node directly to get SIGTERM for graceful shutdown
+CMD ["node", "dist/index.js"]

--- a/samples/ts/ts-replicated-entity-example/Dockerfile
+++ b/samples/ts/ts-replicated-entity-example/Dockerfile
@@ -13,4 +13,4 @@ WORKDIR /home/node/samples/ts/ts-replicated-entity-example
 USER node
 ENV NODE_ENV production
 EXPOSE 8080
-CMD ["npm", "run", "start-no-prestart"]
+CMD ["node", "dist/index.js"]

--- a/samples/ts/ts-valueentity-counter/Dockerfile
+++ b/samples/ts/ts-valueentity-counter/Dockerfile
@@ -44,4 +44,5 @@ USER node
 
 # Run
 EXPOSE 8080
-CMD ["npm", "start"]
+# Call node directly to get SIGTERM for graceful shutdown
+CMD ["node", "dist/index.js"]

--- a/samples/ts/ts-valueentity-shopping-cart/Dockerfile
+++ b/samples/ts/ts-valueentity-shopping-cart/Dockerfile
@@ -44,4 +44,5 @@ USER node
 
 # Run
 EXPOSE 8080
-CMD ["npm", "start"]
+# Call node directly to get SIGTERM for graceful shutdown
+CMD ["node", "dist/index.js"]

--- a/samples/ts/ts-views-example/Dockerfile
+++ b/samples/ts/ts-views-example/Dockerfile
@@ -13,4 +13,4 @@ WORKDIR /home/node/samples/ts/ts-views-example
 USER node
 ENV NODE_ENV production
 EXPOSE 8080
-CMD ["npm", "run", "start-no-prestart"]
+CMD ["node", "dist/index.js"]

--- a/tck/Dockerfile
+++ b/tck/Dockerfile
@@ -20,4 +20,4 @@ ENV HOST 0.0.0.0
 ENV NODE_ENV production
 ENV DEBUG akkaserverless*
 EXPOSE 8080
-CMD ["npm", "start"]
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
Refs https://github.com/lightbend/akkaserverless/issues/5016

If `npm start` (or other commands with `npm`) are used to start a service in a docker container, then when the pod is shutting down the SIGTERM received by `npm` is not propagated to the child process, but it's killed instead. This means the JS SDK doesn't get the SIGTERM for a graceful shutdown, and when it's killed there are unexpected stream closed errors in the proxy.

Looks like there a few ways to fix this. Have gone with calling `node` directly, rather than installing some init wrapper.

Have published a new version of the value entity shopping cart already:

```
gcr.io/akkaserverless-public/samples-js-value-entity-shopping-cart:0.0.3
```