### PR TITLE
chore(docs): add bundles for quickstarts

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -52,8 +52,8 @@ examples:
 	rsync -a --exclude-from=.examplesignore ../samples/ts/ts-eventsourced-shopping-cart/ "${managed_examples}/ts-eventsourced-shopping-cart/"
 
 bundles:
-	bin/bundle.sh --zip "${managed_attachments}/js-customer-registry-quickstart.zip" ../samples/js/js-customer-registry-quickstart
-	bin/bundle.sh --zip "${managed_attachments}/ts-customer-registry-quickstart.zip" ../samples/ts/ts-customer-registry-quickstart
+	bin/bundle.sh --zip "${managed_attachments}/js-customer-registry-quickstart.zip" ../samples/js/js-customer-registry
+	bin/bundle.sh --zip "${managed_attachments}/ts-customer-registry-quickstart.zip" ../samples/ts/ts-customer-registry
 	bin/bundle.sh --zip "${managed_attachments}/js-eventsourced-shopping-cart.zip" ../samples/js/js-eventsourced-shopping-cart
 	bin/bundle.sh --zip "${managed_attachments}/ts-eventsourced-shopping-cart.zip" ../samples/ts/ts-eventsourced-shopping-cart
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,7 +22,7 @@ build: dev
 clean:
 	rm -rf build
 
-managed: attributes apidocs examples
+managed: attributes apidocs examples bundles
 	mkdir -p "${src_managed}"
 	cp src/antora.yml "${src_managed}/antora.yml"
 
@@ -51,6 +51,11 @@ examples:
 	rsync -a --exclude-from=.examplesignore ../samples/ts/ts-valueentity-counter/ "${managed_examples}/ts-valueentity-counter/"
 	rsync -a --exclude-from=.examplesignore ../samples/ts/ts-eventsourced-shopping-cart/ "${managed_examples}/ts-eventsourced-shopping-cart/"
 
+bundles:
+	bin/bundle.sh --zip "${managed_attachments}/js-customer-registry-quickstart.zip" ../samples/js/js-customer-registry-quickstart
+	bin/bundle.sh --zip "${managed_attachments}/ts-customer-registry-quickstart.zip" ../samples/ts/ts-customer-registry-quickstart
+	bin/bundle.sh --zip "${managed_attachments}/js-eventsourced-shopping-cart.zip" ../samples/js/js-eventsourced-shopping-cart
+	bin/bundle.sh --zip "${managed_attachments}/ts-eventsourced-shopping-cart.zip" ../samples/ts/ts-eventsourced-shopping-cart
 
 dev: clean managed validate-xrefs dev-html
 

--- a/docs/bin/bundle.sh
+++ b/docs/bin/bundle.sh
@@ -27,6 +27,7 @@ function _remove_doc_tags {
   # note: use commands that are compatible with both GNU sed and BSD (macOS) sed
   find "$dir" -type f -exec sed -i.bak "/tag::[^\[]*\[.*\]/d" {} \; -exec rm -f {}.bak \;
   find "$dir" -type f -exec sed -i.bak "/end::[^\[]*\[.*\]/d" {} \; -exec rm -f {}.bak \;
+  find "$dir" -type f -exec sed -i.bak "s/\/\/\s<.>//g" {} \; -exec rm -f {}.bak \;
 }
 
 function _bundle {
@@ -54,8 +55,8 @@ function _bundle {
 
   _remove_doc_tags "$sample_bundle_dir"
 
-  pushd "$bundle_dir" > /dev/null
-  zip -q -r "$zip_file" "$sample_name"
+  pushd "$sample_bundle_dir" > /dev/null
+  zip -q -r "$zip_file" .
   popd > /dev/null
 
   echo "Bundled $sample as $zip"

--- a/docs/bin/bundle.sh
+++ b/docs/bin/bundle.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Bundle a sample project for download.
+#
+# Usage:
+#   bundle.sh --zip <file> <dir>
+
+set -euo pipefail
+
+function _script_path {
+  local source="${BASH_SOURCE[0]}"
+  while [ -h "$source" ] ; do
+    local linked="$(readlink "$source")"
+    local dir="$(cd -P $(dirname "$source") && cd -P $(dirname "$linked") && pwd)"
+    source="$dir/$(basename "$linked")"
+  done
+  echo ${source}
+}
+
+readonly script_path=$(_script_path)
+readonly script_dir="$(cd -P "$(dirname "$script_path")" && pwd)"
+readonly docs_dir="$(cd "$script_dir/.." && pwd)"
+readonly bundle_dir="$docs_dir/build/bundle"
+
+function _remove_doc_tags {
+  local -r dir="$1"
+  # note: use commands that are compatible with both GNU sed and BSD (macOS) sed
+  find "$dir" -type f -exec sed -i.bak "/tag::[^\[]*\[.*\]/d" {} \; -exec rm -f {}.bak \;
+  find "$dir" -type f -exec sed -i.bak "/end::[^\[]*\[.*\]/d" {} \; -exec rm -f {}.bak \;
+}
+
+function _bundle {
+  local zip
+  local sample
+  while [[ $# -gt 0 ]] ; do
+    case "$1" in
+      --zip | -z ) zip="$2" ; shift 2 ;;
+      * ) sample=$1 ; shift ;;
+    esac
+  done
+
+  [ -z "$zip" ] && echo "missing required argument for zip file" && exit 1
+  [ -z "$sample" ] && echo "missing required argument for sample directory" && exit 1
+
+  mkdir -p "$bundle_dir"
+  mkdir -p "$(dirname $zip)"
+
+  local -r sample_name="$(basename "$sample")"
+  local -r sample_bundle_dir="$bundle_dir/$sample_name"
+  local -r zip_dir="$(cd -P "$(dirname "$zip")" && pwd)"
+  local -r zip_file="$zip_dir/$(basename "$zip")"
+
+  rsync -a --exclude-from "$sample/.bundleignore" --exclude ".bundleignore" "$sample"/ "$sample_bundle_dir"/
+
+  _remove_doc_tags "$sample_bundle_dir"
+
+  pushd "$bundle_dir" > /dev/null
+  zip -q -r "$zip_file" "$sample_name"
+  popd > /dev/null
+
+  echo "Bundled $sample as $zip"
+}
+
+_bundle "$@"

--- a/docs/bin/bundle.sh
+++ b/docs/bin/bundle.sh
@@ -50,7 +50,7 @@ function _bundle {
   local -r zip_dir="$(cd -P "$(dirname "$zip")" && pwd)"
   local -r zip_file="$zip_dir/$(basename "$zip")"
 
-  rsync -a --exclude-from "$sample/.bundleignore" --exclude ".bundleignore" "$sample"/ "$sample_bundle_dir"/
+  rsync -a --exclude ".bundleignore" "$sample"/ "$sample_bundle_dir"/
 
   _remove_doc_tags "$sample_bundle_dir"
 

--- a/docs/bin/bundle.sh
+++ b/docs/bin/bundle.sh
@@ -27,7 +27,7 @@ function _remove_doc_tags {
   # note: use commands that are compatible with both GNU sed and BSD (macOS) sed
   find "$dir" -type f -exec sed -i.bak "/tag::[^\[]*\[.*\]/d" {} \; -exec rm -f {}.bak \;
   find "$dir" -type f -exec sed -i.bak "/end::[^\[]*\[.*\]/d" {} \; -exec rm -f {}.bak \;
-  find "$dir" -type f -exec sed -i.bak "s/\/\/\s<.>//g" {} \; -exec rm -f {}.bak \;
+  find "$dir" -type f -exec sed -i.bak "s/ *\/\/ *<[0-9][0-9]*>//g" {} \; -exec rm -f {}.bak \;
 }
 
 function _bundle {

--- a/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_api.proto
+++ b/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_api.proto
@@ -66,15 +66,15 @@ service ShoppingCartService {
   }
 
   rpc RemoveItem(RemoveLineItem) returns (google.protobuf.Empty) {
-      option (google.api.http) = {
-        post: "/cart/{cart_id}/items/{product_id}/remove"
-      };
+    option (google.api.http) = {
+      post: "/cart/{cart_id}/items/{product_id}/remove"
+    };
   }
 
   rpc GetCart(GetShoppingCart) returns (Cart) {
-      option (google.api.http) = {
-        get: "/carts/{cart_id}"
-      };
+    option (google.api.http) = {
+      get: "/carts/{cart_id}"
+    };
   }
 }
 // end::service[]

--- a/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_api.proto
+++ b/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_api.proto
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // This is the public API offered by the shopping cart entity.
-/* tag::declarations[] */
+// tag::declarations[]
 syntax = "proto3";
 
 package com.example.shoppingcart;
@@ -21,9 +21,9 @@ package com.example.shoppingcart;
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
 import "akkaserverless/annotations.proto";
-/* end::declarations[] */
+// end::declarations[] 
 
-/* tag::messages1[] */
+// tag::messages1[]
 message Cart {
   repeated LineItem items = 1;
 }
@@ -33,8 +33,8 @@ message LineItem {
   string name = 2;
   int32 quantity = 3;
 }
-/* end::messages1[] */
-/* tag::messages2[] */
+// end::messages1[]
+// tag::messages2[]
 message AddLineItem {
   string cart_id = 1 [(akkaserverless.field).entity_key = true];
   string product_id = 2;
@@ -50,8 +50,8 @@ message RemoveLineItem {
 message GetShoppingCart {
   string cart_id = 1 [(akkaserverless.field).entity_key = true];
 }
-/* end::messages2[] */
-/* tag::service[] */
+// end::messages2[]
+// tag::service[]
 service ShoppingCartService {
   option (akkaserverless.service) = {
     type: SERVICE_TYPE_ENTITY
@@ -77,4 +77,4 @@ service ShoppingCartService {
       };
   }
 }
-/* end::service[] */
+// end::service[]

--- a/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_api.proto
+++ b/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_api.proto
@@ -60,20 +60,20 @@ service ShoppingCartService {
 
   rpc AddItem(AddLineItem) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-        post: "/cart/{user_id}/items/add"
-        body: "*"
+      post: "/cart/{cart_id}/items/add"
+      body: "*"
     };
   }
 
   rpc RemoveItem(RemoveLineItem) returns (google.protobuf.Empty) {
       option (google.api.http) = {
-          post: "/cart/{user_id}/items/{product_id}/remove";
+        post: "/cart/{user_id}/items/{product_id}/remove"
       };
   }
 
   rpc GetCart(GetShoppingCart) returns (Cart) {
       option (google.api.http) = {
-          get: "/carts/{user_id}"
+        get: "/carts/{user_id}"
       };
   }
 }

--- a/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_api.proto
+++ b/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_api.proto
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // This is the public API offered by the shopping cart entity.
-
+/* tag::declarations[] */
 syntax = "proto3";
 
 package com.example.shoppingcart;
@@ -21,7 +21,20 @@ package com.example.shoppingcart;
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
 import "akkaserverless/annotations.proto";
+/* end::declarations[] */
 
+/* tag::messages1[] */
+message Cart {
+  repeated LineItem items = 1;
+}
+
+message LineItem {
+  string product_id = 1;
+  string name = 2;
+  int32 quantity = 3;
+}
+/* end::messages1[] */
+/* tag::messages2[] */
 message AddLineItem {
   string cart_id = 1 [(akkaserverless.field).entity_key = true];
   string product_id = 2;
@@ -37,17 +50,8 @@ message RemoveLineItem {
 message GetShoppingCart {
   string cart_id = 1 [(akkaserverless.field).entity_key = true];
 }
-
-message LineItem {
-  string product_id = 1;
-  string name = 2;
-  int32 quantity = 3;
-}
-
-message Cart {
-  repeated LineItem items = 1;
-}
-
+/* end::messages2[] */
+/* tag::service[] */
 service ShoppingCartService {
   option (akkaserverless.service) = {
     type: SERVICE_TYPE_ENTITY
@@ -56,22 +60,21 @@ service ShoppingCartService {
 
   rpc AddItem(AddLineItem) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      post: "/cart/{cart_id}/items/add"
-      body: "*"
+        post: "/cart/{user_id}/items/add"
+        body: "*"
     };
   }
 
   rpc RemoveItem(RemoveLineItem) returns (google.protobuf.Empty) {
-    option (google.api.http).post = "/cart/{cart_id}/items/{product_id}/remove";
+      option (google.api.http) = {
+          post: "/cart/{user_id}/items/{product_id}/remove";
+      };
   }
 
   rpc GetCart(GetShoppingCart) returns (Cart) {
-    option (google.api.http) = {
-      get: "/carts/{cart_id}"
-      additional_bindings: {
-        get: "/carts/{cart_id}/items"
-        response_body: "items"
-      }
-    };
+      option (google.api.http) = {
+          get: "/carts/{user_id}"
+      };
   }
 }
+/* end::service[] */

--- a/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_api.proto
+++ b/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_api.proto
@@ -67,13 +67,13 @@ service ShoppingCartService {
 
   rpc RemoveItem(RemoveLineItem) returns (google.protobuf.Empty) {
       option (google.api.http) = {
-        post: "/cart/{user_id}/items/{product_id}/remove"
+        post: "/cart/{cart_id}/items/{product_id}/remove"
       };
   }
 
   rpc GetCart(GetShoppingCart) returns (Cart) {
       option (google.api.http) = {
-        get: "/carts/{user_id}"
+        get: "/carts/{cart_id}"
       };
   }
 }

--- a/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_domain.proto
+++ b/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_domain.proto
@@ -14,12 +14,13 @@
 
 // These are the messages that get persisted - the events, plus the current
 // state (Cart) for snapshots.
-
+/* tag::declarations[] */
 syntax = "proto3";
 
 package com.example.shoppingcart.domain;
 
 import "akkaserverless/annotations.proto";
+/* end::declarations[] */
 // tag::proto_state[]
 // Describes how this domain relates to an event sourced entity
 option (akkaserverless.file).event_sourced_entity = {
@@ -30,12 +31,7 @@ option (akkaserverless.file).event_sourced_entity = {
   events: "ItemRemoved"
 };
 // end::proto_state[]
-message LineItem {
-  string productId = 1;
-  string name = 2;
-  int32 quantity = 3;
-}
-
+/* tag::events[] */
 // The item added event.
 message ItemAdded {
   LineItem item = 1;
@@ -45,8 +41,16 @@ message ItemAdded {
 message ItemRemoved {
   string productId = 1;
 }
-
+/* end::events[] */
+/* tag::state[] */
 // The shopping cart state.
 message Cart {
   repeated LineItem items = 1;
 }
+
+message LineItem {
+  string productId = 1;
+  string name = 2;
+  int32 quantity = 3;
+}
+/* end::state[] */

--- a/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_domain.proto
+++ b/samples/js/js-eventsourced-shopping-cart/proto/shoppingcart_domain.proto
@@ -14,13 +14,13 @@
 
 // These are the messages that get persisted - the events, plus the current
 // state (Cart) for snapshots.
-/* tag::declarations[] */
+// tag::declarations[]
 syntax = "proto3";
 
 package com.example.shoppingcart.domain;
 
 import "akkaserverless/annotations.proto";
-/* end::declarations[] */
+// end::declarations[]
 // tag::proto_state[]
 // Describes how this domain relates to an event sourced entity
 option (akkaserverless.file).event_sourced_entity = {
@@ -31,7 +31,7 @@ option (akkaserverless.file).event_sourced_entity = {
   events: "ItemRemoved"
 };
 // end::proto_state[]
-/* tag::events[] */
+// tag::events[]
 // The item added event.
 message ItemAdded {
   LineItem item = 1;
@@ -41,8 +41,8 @@ message ItemAdded {
 message ItemRemoved {
   string productId = 1;
 }
-/* end::events[] */
-/* tag::state[] */
+// end::events[]
+// tag::state[]
 // The shopping cart state.
 message Cart {
   repeated LineItem items = 1;
@@ -53,4 +53,4 @@ message LineItem {
   string name = 2;
   int32 quantity = 3;
 }
-/* end::state[] */
+// end::state[]

--- a/samples/js/js-eventsourced-shopping-cart/src/index.js
+++ b/samples/js/js-eventsourced-shopping-cart/src/index.js
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/* tag::imports[] */
 import { AkkaServerless } from "@lightbend/akkaserverless-javascript-sdk";
 import generatedComponents from "../lib/generated/index.js";
-
+/* end::imports[] */
+/* tag::server[] */
 const server = new AkkaServerless();
 
 generatedComponents.forEach((component) => {
@@ -24,3 +25,4 @@ generatedComponents.forEach((component) => {
 });
 
 server.start();
+/* end::server[] */

--- a/samples/js/js-eventsourced-shopping-cart/src/index.js
+++ b/samples/js/js-eventsourced-shopping-cart/src/index.js
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* tag::imports[] */
+// tag::imports[]
 import { AkkaServerless } from "@lightbend/akkaserverless-javascript-sdk";
 import generatedComponents from "../lib/generated/index.js";
-/* end::imports[] */
-/* tag::server[] */
+// end::imports[]
+// tag::server[]
 const server = new AkkaServerless();
 
 generatedComponents.forEach((component) => {
@@ -25,4 +25,4 @@ generatedComponents.forEach((component) => {
 });
 
 server.start();
-/* end::server[] */
+// end::server[]

--- a/samples/js/js-eventsourced-shopping-cart/src/shoppingcart.js
+++ b/samples/js/js-eventsourced-shopping-cart/src/shoppingcart.js
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* tag::imports[] */
+// tag::imports[]
 import {EventSourcedEntity} from "@lightbend/akkaserverless-javascript-sdk";
-/* end::imports[] */
+// end::imports[]
 /**
  * Type definitions.
  * These types have been generated based on your proto source.
@@ -34,7 +34,7 @@ import {EventSourcedEntity} from "@lightbend/akkaserverless-javascript-sdk";
 /**
  * @type ShoppingCartService
  */
-/* tag::esentity[] */
+// tag::esentity[]
 const entity = new EventSourcedEntity(
   [
     "shoppingcart_domain.proto",
@@ -47,7 +47,7 @@ const entity = new EventSourcedEntity(
     serializeFallbackToJson: true
   }
 );
-/* end::esentity[] */
+// end::esentity[]
 /*
  * Here we load the Protobuf types. When emitting events or setting state, we need to return
  * protobuf message objects, not just ordinary JavaScript objects, so that the framework can
@@ -55,12 +55,12 @@ const entity = new EventSourcedEntity(
  *
  * Note this shows loading them dynamically, they could also be compiled and statically loaded.
  */
-/* tag::espersistence[] */
+// tag::espersistence[]
 const pkg = "com.example.shoppingcart.domain.";
 const ItemAdded = entity.lookupType(pkg + "ItemAdded");
 const ItemRemoved = entity.lookupType(pkg + "ItemRemoved");
 const Cart = entity.lookupType(pkg + "Cart");
-/* end::espersistence[] */
+// end::espersistence[]
 /*
  * Set a callback to create the initial state. This is what is created if there is no
  * snapshot to load.
@@ -68,10 +68,10 @@ const Cart = entity.lookupType(pkg + "Cart");
  * We can ignore the cartId parameter if we want, it's the id of the entity, which is
  * automatically associated with all events and state for this entity.
  */
-/* tag::initialstate[] */
+// tag::initialstate[]
 entity.setInitial(cartId => Cart.create({items: []}));
-/* end::initialstate[] */
-/* tag::behavior[] */
+// end::initialstate[]
+// tag::behavior[]
 entity.setBehavior(cart => {
   return {
     // Command handlers. The name of the command corresponds to the name of the rpc call in
@@ -89,13 +89,13 @@ entity.setBehavior(cart => {
     }
   };
 });
-/* end::behavior[] */
+// end::behavior[]
 
 
 /**
  * Handler for add item commands.
  */
-/* tag::additem[] */
+// tag::additem[]
 function addItem(addItem, cart, ctx) {
   // Validation:
   // Make sure that it is not possible to add negative quantities
@@ -115,11 +115,11 @@ function addItem(addItem, cart, ctx) {
     return {};
   }
 }
-/* end::additem[] */
+// end::additem[]
 /**
  * Handler for remove item commands.
  */
-/* tag::removeitem[] */
+// tag::removeitem[]
 function removeItem(removeItem, cart, ctx) {
   // Validation:
   // Check that the item that we're removing actually exists.
@@ -139,20 +139,20 @@ function removeItem(removeItem, cart, ctx) {
     return {};
   }
 }
-/* end::removeitem[] */
+// end::removeitem[]
 /**
  * Handler for get cart commands.
  */
-/* tag::getcart[] */
+// tag::getcart[]
 function getCart(request, cart) {
   // Simply return the shopping cart as is.
   return cart;
 }
-/* end::getcart[] */
+// end::getcart[]
 /**
  * Handler for item added events.
  */
-/* tag::itemadded[] */
+// tag::itemadded[]
 function itemAdded(added, cart) {
   // If there is an existing item with that product id, we need to increment its quantity.
   const existing = cart.items.find(item => {
@@ -169,11 +169,11 @@ function itemAdded(added, cart) {
   // And return the new state.
   return cart;
 }
-/* end::itemadded[] */
+// end::itemadded[]
 /**
  * Handler for item removed events.
  */
-/* tag::itemremoved[] */
+// tag::itemremoved[]
 function itemRemoved(removed, cart) {
   // Filter the removed item from the items by product id.
   cart.items = cart.items.filter(item => {
@@ -183,8 +183,8 @@ function itemRemoved(removed, cart) {
   // And return the new state.
   return cart;
 }
-/* end::itemremoved[] */
+// end::itemremoved[]
 
-/* tag::export[] */
+// tag::export[]
 export default entity;
-/* end::export[] */
+// end::export[]

--- a/samples/js/js-eventsourced-shopping-cart/src/shoppingcart.js
+++ b/samples/js/js-eventsourced-shopping-cart/src/shoppingcart.js
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/* tag::imports[] */
 import {EventSourcedEntity} from "@lightbend/akkaserverless-javascript-sdk";
-
+/* end::imports[] */
 /**
  * Type definitions.
  * These types have been generated based on your proto source.
@@ -34,6 +34,7 @@ import {EventSourcedEntity} from "@lightbend/akkaserverless-javascript-sdk";
 /**
  * @type ShoppingCartService
  */
+/* tag::esentity[] */
 const entity = new EventSourcedEntity(
   [
     "shoppingcart_domain.proto",
@@ -46,7 +47,7 @@ const entity = new EventSourcedEntity(
     serializeFallbackToJson: true
   }
 );
-
+/* end::esentity[] */
 /*
  * Here we load the Protobuf types. When emitting events or setting state, we need to return
  * protobuf message objects, not just ordinary JavaScript objects, so that the framework can
@@ -54,11 +55,12 @@ const entity = new EventSourcedEntity(
  *
  * Note this shows loading them dynamically, they could also be compiled and statically loaded.
  */
+/* tag::espersistence[] */
 const pkg = "com.example.shoppingcart.domain.";
 const ItemAdded = entity.lookupType(pkg + "ItemAdded");
 const ItemRemoved = entity.lookupType(pkg + "ItemRemoved");
 const Cart = entity.lookupType(pkg + "Cart");
-
+/* end::espersistence[] */
 /*
  * Set a callback to create the initial state. This is what is created if there is no
  * snapshot to load.
@@ -66,8 +68,10 @@ const Cart = entity.lookupType(pkg + "Cart");
  * We can ignore the cartId parameter if we want, it's the id of the entity, which is
  * automatically associated with all events and state for this entity.
  */
+/* tag::initialstate[] */
 entity.setInitial(cartId => Cart.create({items: []}));
-
+/* end::initialstate[] */
+/* tag::behavior[] */
 entity.setBehavior(cart => {
   return {
     // Command handlers. The name of the command corresponds to the name of the rpc call in
@@ -85,11 +89,13 @@ entity.setBehavior(cart => {
     }
   };
 });
+/* end::behavior[] */
 
 
 /**
  * Handler for add item commands.
  */
+/* tag::additem[] */
 function addItem(addItem, cart, ctx) {
   // Validation:
   // Make sure that it is not possible to add negative quantities
@@ -109,10 +115,11 @@ function addItem(addItem, cart, ctx) {
     return {};
   }
 }
-
+/* end::additem[] */
 /**
  * Handler for remove item commands.
  */
+/* tag::removeitem[] */
 function removeItem(removeItem, cart, ctx) {
   // Validation:
   // Check that the item that we're removing actually exists.
@@ -132,18 +139,20 @@ function removeItem(removeItem, cart, ctx) {
     return {};
   }
 }
-
+/* end::removeitem[] */
 /**
  * Handler for get cart commands.
  */
+/* tag::getcart[] */
 function getCart(request, cart) {
   // Simply return the shopping cart as is.
   return cart;
 }
-
+/* end::getcart[] */
 /**
  * Handler for item added events.
  */
+/* tag::itemadded[] */
 function itemAdded(added, cart) {
   // If there is an existing item with that product id, we need to increment its quantity.
   const existing = cart.items.find(item => {
@@ -160,10 +169,11 @@ function itemAdded(added, cart) {
   // And return the new state.
   return cart;
 }
-
+/* end::itemadded[] */
 /**
  * Handler for item removed events.
  */
+/* tag::itemremoved[] */
 function itemRemoved(removed, cart) {
   // Filter the removed item from the items by product id.
   cart.items = cart.items.filter(item => {
@@ -173,6 +183,8 @@ function itemRemoved(removed, cart) {
   // And return the new state.
   return cart;
 }
+/* end::itemremoved[] */
 
-
+/* tag::export[] */
 export default entity;
+/* end::export[] */


### PR DESCRIPTION
This PR:

- Adds bundling script and makefile target to create quickstart zip files (copied from the Java SDK)
- Adds antora tags to the JavaScript Event Sourced Shopping cart so it can be used in the quickstarts