### PR TITLE
fix: pin node-fetch version for protoc download

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -37,7 +37,7 @@
     "json-stable-stringify": "^1.0.1",
     "minimist": ">=0.2.1",
     "mkdirp": "^0.5.1",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "2.6.1",
     "rimraf": "^2.6.3",
     "test": "^0.6.0",
     "testcontainers": "7.5.0",


### PR DESCRIPTION
Builds have started failing on protoc download for samples. See #184 and #187.

```
Error: invalid signature: 0x6d783f3c
    at akkaserverless/javascript-sdk/main/samples/js/valueentity-counter/node_modules/unzipper/lib/parse.js:62:26
    at tryCatcher (akkaserverless/javascript-sdk/main/samples/js/valueentity-counter/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (akkaserverless/javascript-sdk/main/samples/js/valueentity-counter/node_modules/bluebird/js/release/promise.js:510:31)
    at Promise._settlePromise (akkaserverless/javascript-sdk/main/samples/js/valueentity-counter/node_modules/bluebird/js/release/promise.js:567:18)
    at Promise._settlePromise0 (akkaserverless/javascript-sdk/main/samples/js/valueentity-counter/node_modules/bluebird/js/release/promise.js:612:10)
    at Promise._settlePromises (akkaserverless/javascript-sdk/main/samples/js/valueentity-counter/node_modules/bluebird/js/release/promise.js:691:18)
    at Async._drainQueue (akkaserverless/javascript-sdk/main/samples/js/valueentity-counter/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (akkaserverless/javascript-sdk/main/samples/js/valueentity-counter/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues [as _onImmediate] (akkaserverless/javascript-sdk/main/samples/js/valueentity-counter/node_modules/bluebird/js/release/async.js:17:14)
    at processImmediate (internal/timers.js:464:21)
```

Turns out it's a problem with the new patch version of `node-fetch`. Projects will use version `2.6.3` which has the above issue. This will break all projects using the SDK currently. Haven't looked at what exactly the issue is; there's only a URL encoding fix in that patch.

Pinning to the known-to-work version should fix things for now. This will need a new SDK release.