### PR TITLE
docs: add bundle ignores for build artifacts and generated code

### DIFF
--- a/docs/bin/bundle.sh
+++ b/docs/bin/bundle.sh
@@ -51,7 +51,7 @@ function _bundle {
   local -r zip_dir="$(cd -P "$(dirname "$zip")" && pwd)"
   local -r zip_file="$zip_dir/$(basename "$zip")"
 
-  rsync -a --exclude ".bundleignore" "$sample"/ "$sample_bundle_dir"/
+  rsync -a --exclude-from "$sample/.bundleignore" --exclude ".bundleignore" "$sample"/ "$sample_bundle_dir"/
 
   _remove_doc_tags "$sample_bundle_dir"
 

--- a/samples/js/js-customer-registry/.bundleignore
+++ b/samples/js/js-customer-registry/.bundleignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+user-function.desc

--- a/samples/js/js-eventsourced-shopping-cart/.bundleignore
+++ b/samples/js/js-eventsourced-shopping-cart/.bundleignore
@@ -1,0 +1,4 @@
+lib/generated
+node_modules
+package-lock.json
+user-function.desc

--- a/samples/ts/ts-customer-registry/.bundleignore
+++ b/samples/ts/ts-customer-registry/.bundleignore
@@ -1,0 +1,5 @@
+dist
+lib/generated
+node_modules
+package-lock.json
+user-function.desc

--- a/samples/ts/ts-eventsourced-shopping-cart/.bundleignore
+++ b/samples/ts/ts-eventsourced-shopping-cart/.bundleignore
@@ -1,0 +1,5 @@
+dist
+lib/generated
+node_modules
+package-lock.json
+user-function.desc


### PR DESCRIPTION
Didn't notice that #184 was missing the bundle ignore, so the sample zips can include `node_modules` and generated or compiled files. Have also excluded `package-lock.json` as some samples have this gitignored already.