### PR TITLE
feat: provide promisified clients for inter-service calls

### DIFF
--- a/docs/src/modules/javascript/pages/call-another-service.adoc
+++ b/docs/src/modules/javascript/pages/call-another-service.adoc
@@ -32,13 +32,10 @@ In our delegating service implementation:
 ----
 include::example$js-doc-snippets/src/delegatingservice.js[tag=delegating-action]
 ----
-<1> Import `grpc-js`, we need later to create the client.
-<2> Import `GrpcUtil` from the Akka Serverless JS SDK.
-<3> Include the `proto` file of the other service in the action service descriptors.
-<4> Wrap the client with `GrpcUtil.promisifyClient` to get async methods.
-<5> Use the name that the other Akka Serverless service was deployed as, in this case `counter` and port `80`.
-<6> Use a cleartext connection as TLS is handled transparently for us.
-<7> We can now call the various methods on the other service with their method names directly on the client. The calls return promises so we can use `await/async` to interact with them.
+<1> Include the `proto` file of the other service in the action service descriptors.
+<2> Create the client using the provided creators to get async methods. Defaults to a cleartext connection as TLS is handled transparently for us.
+<3> Use the name that the other Akka Serverless service was deployed as, in this case `counter` and port `80`.
+<4> We can now call the various methods on the other service with their method names directly on the client. The calls return promises so we can use `await/async` to interact with them.
 
 == External gRPC services
 
@@ -49,8 +46,7 @@ Calling an Akka Serverless service in another project, or an arbitrary external 
 ----
 include::example$js-doc-snippets/src/delegatingservice.js[tag=public-grpc]
 ----
-
-
-
-
-
+<1> Import `grpc-js`, to provide credentials when creating the client.
+<2> Create the client using the provided creators to get async methods.
+<3> Use the full public hostname of the service.
+<4> Enable TLS/HTTPS to encrypt the connection.

--- a/samples/js/js-doc-snippets/src/delegatingservice.js
+++ b/samples/js/js-doc-snippets/src/delegatingservice.js
@@ -22,8 +22,12 @@
 // tag::delegating-action[]
 import { Action } from "@lightbend/akkaserverless-javascript-sdk";
 import { replies } from '@lightbend/akkaserverless-javascript-sdk';
+// end::delegating-action[]
+// tag::public-grpc[]
 import * as grpc from '@grpc/grpc-js'; // <1>
-import { GrpcUtil } from '@lightbend/akkaserverless-javascript-sdk'; // <2>
+
+// end::public-grpc[]
+// tag::delegating-action[]
 
 /**
  * Type definitions.
@@ -40,33 +44,32 @@ import { GrpcUtil } from '@lightbend/akkaserverless-javascript-sdk'; // <2>
 const action = new Action(
   [
     "com/example/delegating_service.proto",
-    "com/example/counter_api.proto" // <3>
+    "com/example/counter_api.proto" // <1>
   ],
   "com.example.DelegatingService",
   {
-    includeDirs: ["./proto"],
-    serializeFallbackToJson: true
+    includeDirs: ["./proto"]
   }
 );
 
-const counterClient = GrpcUtil.promisifyClient(new action.grpc.com.example.CounterService( // <4>
-  "counter:80", // <5>
-  grpc.credentials.createInsecure())); // <6>
+const counterClient = action.clients.com.example.CounterService.createClient( // <2>
+  "counter:80" // <3>
+);
 
 // end::delegating-action[]
-function showExternal() {
-  // tag::public-grpc[]
-  const counterClient = GrpcUtil.promisifyClient(new action.grpc.com.example.CounterService(
-    "still-queen-1447.us-east1.apps.akkaserverless.dev",
-    grpc.credentials.createSsl());
-  // end::public-grpc[]
+{
+// tag::public-grpc[]
+const counterClient = action.clients.com.example.CounterService.createClient( // <2>
+  "still-queen-1447.us-east1.apps.akkaserverless.dev", // <3>
+  grpc.credentials.createSsl() // <4>
+);
+// end::public-grpc[]
 }
 // tag::delegating-action[]
 
-
 action.commandHandlers = {
-  async AddAndReturn(request, ctx) {
-    await counterClient.increase({counterId: request.counterId, value: 1}); // <7>
+  async AddAndReturn(request) {
+    await counterClient.increase({counterId: request.counterId, value: 1}); // <4>
     const currentCounter = await counterClient.getCurrentCounter({counterId: request.counterId });
     return replies.message({value: currentCounter.value });
   }

--- a/sdk/bin/prepare.sh
+++ b/sdk/bin/prepare.sh
@@ -2,32 +2,35 @@
 
 # Prepare script for the akkaserverless-javascript-sdk package
 
-# Delete and recreate the proto directory
-rm -rf ./proto
-mkdir -p ./proto
-
 # get the framework version from config.json
 readonly framework_version=$(node --print 'require("./config.json").frameworkVersion')
 
 function download_protocol {
   local module="$1"
+  mkdir -p ./proto
   curl -OL "https://repo1.maven.org/maven2/com/akkaserverless/akkaserverless-$module-protocol/$framework_version/akkaserverless-$module-protocol-$framework_version.zip"
   unzip "akkaserverless-$module-protocol-$framework_version.zip"
   cp -r "akkaserverless-$module-protocol-$framework_version"/* proto
   rm -rf "akkaserverless-$module-protocol-$framework_version.zip" "akkaserverless-$module-protocol-$framework_version"
 }
 
-if [ -n "$PROXY_SNAPSHOT_DIRECTORY" ]; then
-   # Use local proxy and sdk sources, useful for development, point PROXY_SNAPSHOTS_DIRECTORY to the local
-   # proxy project source directory
-   echo "Using snapshot of proxy and sdk protocols from '$PROXY_SNAPSHOT_DIRECTORY'"
-   cp -rf $PROXY_SNAPSHOT_DIRECTORY/protocols/proxy/src/main/protobuf/* ./proto/
-   cp -rf $PROXY_SNAPSHOT_DIRECTORY/protocols/sdk/src/main/protobuf/* ./proto/
- else
-   # Download and unzip the proxy and SDK protocols to the proto directory
-   download_protocol proxy
-   download_protocol sdk
- fi
+# Need to delete the proto directory and generated files to rebuild (including local snapshot versions)
+if [ -d "./proto" ] ; then
+  echo "Protocol already built ('npm run clean' first to fetch and compile again)"
+  echo
+else
+  if [ -n "$PROXY_SNAPSHOT_DIRECTORY" ]; then
+     # Use local proxy and sdk sources, useful for development, point PROXY_SNAPSHOTS_DIRECTORY to the local
+     # proxy project source directory
+     echo "Using snapshot of proxy and sdk protocols from '$PROXY_SNAPSHOT_DIRECTORY'"
+     cp -rf $PROXY_SNAPSHOT_DIRECTORY/protocols/proxy/src/main/protobuf/* ./proto/
+     cp -rf $PROXY_SNAPSHOT_DIRECTORY/protocols/sdk/src/main/protobuf/* ./proto/
+   else
+     # Download and unzip the proxy and SDK protocols to the proto directory
+     download_protocol proxy
+     download_protocol sdk
+   fi
+fi
 
 # Compile protobuf
 ./bin/compile-protobuf.sh
@@ -40,5 +43,5 @@ cat types.d.ts >> index.d.ts && rm -f types.d.ts
 perl -i -pe 's/declare module \"akkaserverless\"/declare module \"\@lightbend\/akkaserverless-javascript-sdk\"/g' index.d.ts
 perl -i -pe 's/module:akkaserverless\.//g' index.d.ts
 perl -i -pe 's/import\("akkaserverless"\).([a-zA-Z]*)/$1/g' index.d.ts
-perl -i -pe 's/import\("akkaserverless\.([a-zA-Z.]*)([a-zA-Z]*)\"\).(?!default\W)([a-zA-Z]*)/$1$2.$3/g' index.d.ts
-perl -i -pe 's/import\("akkaserverless\.([a-zA-Z.]*)([a-zA-Z]*)\"\)([.a-zA-Z]*)/$1$2/g' index.d.ts
+perl -i -pe 's/import\("akkaserverless\.([a-zA-Z.|]*)\"\).(?!default\W)([a-zA-Z]*)/$1.$2/g' index.d.ts
+perl -i -pe 's/import\("akkaserverless\.([a-zA-Z.|]*)\"\).default/$1/g' index.d.ts

--- a/sdk/index.d.preamble.ts
+++ b/sdk/index.d.preamble.ts
@@ -15,3 +15,4 @@
  */
 
 import * as protobuf from 'protobufjs';
+import * as grpc from '@grpc/grpc-js';

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -79,7 +79,7 @@
     }
   },
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rm -rf ./dist ./proto",
     "copy-files": "cp -r ./proto ./dist && cp index.d.ts ./dist",
     "compile": "tsc && npm run copy-files",
     "verify-types": "tsc dist/index.d.ts --noEmit",

--- a/sdk/src/action.js
+++ b/sdk/src/action.js
@@ -20,6 +20,7 @@ const grpc = require('@grpc/grpc-js');
 const protoLoader = require('@grpc/proto-loader');
 const ActionSupport = require('./action-support');
 const AkkaServerless = require('./akkaserverless');
+const { GrpcUtil } = require('./grpc-util');
 
 const actionServices = new ActionSupport();
 
@@ -119,6 +120,13 @@ class Action {
       includeDirs: allIncludeDirs,
     });
     this.grpc = grpc.loadPackageDefinition(packageDefinition);
+
+    /**
+     * Access to gRPC clients (with promisified unary methods).
+     *
+     * @type module:akkaserverless.GrpcClientLookup
+     */
+    this.clients = GrpcUtil.clientCreators(this.root, this.grpc);
 
     /**
      * The command handlers.

--- a/sdk/src/event-sourced-entity.js
+++ b/sdk/src/event-sourced-entity.js
@@ -20,6 +20,7 @@ const grpc = require('@grpc/grpc-js');
 const protoLoader = require('@grpc/proto-loader');
 const EventSourcedEntityServices = require('./event-sourced-entity-support');
 const AkkaServerless = require('./akkaserverless');
+const { GrpcUtil } = require('./grpc-util');
 
 const eventSourcedEntityServices = new EventSourcedEntityServices();
 
@@ -156,6 +157,13 @@ class EventSourcedEntity {
       includeDirs: allIncludeDirs,
     });
     this.grpc = grpc.loadPackageDefinition(packageDefinition);
+
+    /**
+     * Access to gRPC clients (with promisified unary methods).
+     *
+     * @type module:akkaserverless.GrpcClientLookup
+     */
+    this.clients = GrpcUtil.clientCreators(this.root, this.grpc);
   }
 
   /**

--- a/sdk/src/grpc-util.jsdoc
+++ b/sdk/src/grpc-util.jsdoc
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * gRPC client.
+ *
+ * @interface module:akkaserverless.GrpcClient
+ * @extends grpc.Client
+ */
+
+/**
+ * gRPC client creator for a service.
+ * 
+ * @interface module:akkaserverless.GrpcClientCreator
+ */
+
+/**
+ * Create a new client for service.
+ *
+ * @function module:akkaserverless.GrpcClientCreator#createClient
+ * @param {string} address the address for the service
+ * @param {grpc.ChannelCredentials} [credentials] the credentials for the connection
+ * @returns {module:akkaserverless.GrpcClient} a new gRPC client for the service
+ */
+
+/**
+ * gRPC client lookup, using fully qualified name for service.
+ * 
+ * @typedef module:akkaserverless.GrpcClientLookup
+ * @type {Object.<string, (module:akkaserverless.GrpcClientLookup | module:akkaserverless.GrpcClientCreator)>}
+ */

--- a/sdk/src/replicated-entity.js
+++ b/sdk/src/replicated-entity.js
@@ -21,6 +21,7 @@ const protoLoader = require('@grpc/proto-loader');
 const AkkaServerless = require('./akkaserverless');
 const replicatedData = require('./replicated-data');
 const support = require('./replicated-entity-support');
+const { GrpcUtil } = require('./grpc-util');
 
 const replicatedEntityServices = new support.ReplicatedEntityServices();
 
@@ -156,6 +157,13 @@ class ReplicatedEntity {
       includeDirs: allIncludeDirs,
     });
     this.grpc = grpc.loadPackageDefinition(packageDefinition);
+
+    /**
+     * Access to gRPC clients (with promisified unary methods).
+     *
+     * @type module:akkaserverless.GrpcClientLookup
+     */
+    this.clients = GrpcUtil.clientCreators(this.root, this.grpc);
 
     /**
      * The command handlers.

--- a/sdk/src/value-entity.js
+++ b/sdk/src/value-entity.js
@@ -20,6 +20,7 @@ const grpc = require('@grpc/grpc-js');
 const protoLoader = require('@grpc/proto-loader');
 const ValueEntityServices = require('./value-entity-support');
 const AkkaServerless = require('./akkaserverless');
+const { GrpcUtil } = require('./grpc-util');
 
 const valueEntityServices = new ValueEntityServices();
 
@@ -125,6 +126,13 @@ class ValueEntity {
       includeDirs: allIncludeDirs,
     });
     this.grpc = grpc.loadPackageDefinition(packageDefinition);
+
+    /**
+     * Access to gRPC clients (with promisified unary methods).
+     *
+     * @type module:akkaserverless.GrpcClientLookup
+     */
+    this.clients = GrpcUtil.clientCreators(this.root, this.grpc);
   }
 
   /**


### PR DESCRIPTION
Follow-up to #186. Try creating promisified gRPC clients automatically. A bit awkward to rebuild the package structure, and grpc-js doesn't export all of its types. Simplifies things a bit more on the user-side.

Haven't looked at the jsdoc types yet, or added this to other components.