### PR TITLE
docs: add javascript/typescript supergroup for tabbed code snippets

### DIFF
--- a/docs/src/modules/javascript/pages/actions.adoc
+++ b/docs/src/modules/javascript/pages/actions.adoc
@@ -1,4 +1,5 @@
 = Actions
+:page-supergroup-javascript-typescript: Language
 
 include::ROOT:partial$include.adoc[]
 include::partial$actions.adoc[]
@@ -15,14 +16,14 @@ include::example$action/service.proto[]
 The following shows the implementation:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,javascript]
 ----
 include::example$action/src/action.js[]
 ----
 
-TS::
+TypeScript::
 +
 [source,typescript]
 ----

--- a/docs/src/modules/javascript/pages/eventsourced.adoc
+++ b/docs/src/modules/javascript/pages/eventsourced.adoc
@@ -1,4 +1,5 @@
 = Implementing Event Sourced Entities in JavaScript
+:page-supergroup-javascript-typescript: Language
 
 include::ROOT:partial$include.adoc[]
 include::partial$eventsourced.adoc[]
@@ -25,14 +26,14 @@ Create an Event Sourced Entity with the link:{attachmentsdir}/api/module-akkaser
 ifdef::todo[TODO: update with new SDK names.]
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=entity-class]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -57,14 +58,14 @@ When you pass an event or snapshot to persist, Akka Serverless needs to know how
 The `EventSourced` class provides a helper method called link:{attachmentsdir}/api/module-akkaserverless.EventSourcedEntity.html#lookupType[`lookupType`{tab-icon}, window="new"]. So before implementing, we'll use `lookupType` to get these types to use later.
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=lookup-type]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -78,14 +79,14 @@ When there are no snapshots persisted for an entity (such as when the entity is 
 To create the initial state, we set the link:{attachmentsdir}/api/module-akkaserverless.EventSourcedEntity.html#initial[`initial`{tab-icon}, window="new"] callback. This takes the id of the entity being created, and returns a new empty state, in this case, an empty shopping cart:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=initial]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -109,14 +110,14 @@ The command handler must return a message of the same type as the output type of
 The following shows the implementation of the `GetCart` command handler. This command handler is a read-only command handler, it doesn't emit any events, it just returns some state:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=get-cart]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -134,14 +135,14 @@ A command handler may emit an event by using the link:{attachmentsdir}/api/modul
 The following command handler example emits an event:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=add-item]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -166,14 +167,14 @@ Event handlers take the event they are handling, and the state, and must return 
 Here's an example event handler for the `ItemAdded` event:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=item-added]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -187,14 +188,14 @@ Once you have command handler and event handler functions implemented, you can s
 The behavior callback can be set by setting the link:{attachmentsdir}/api/module-akkaserverless.EventSourcedEntity.html#behavior[`behavior`{tab-icon}, window="new"] property on the entity:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=behavior]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -214,14 +215,14 @@ The Entity's behavior can be changed by returning different sets of handlers fro
 In the example below, we show a shopping cart that also has a checkout command. Once checked out, the shopping cart no longer accepts any commands to add or remove items, its state and therefore behavior changes:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=multiple-behaviors]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -233,14 +234,14 @@ include::example$test/eventsourced/shoppingcart.ts[tag=multiple-behaviors]
 You can let Akka Serverless start entities by adding the entities to an `Akka Serverless server` instance:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=add-entity]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----

--- a/docs/src/modules/javascript/pages/index.adoc
+++ b/docs/src/modules/javascript/pages/index.adoc
@@ -1,4 +1,5 @@
 = Developing with JavaScript
+:page-supergroup-javascript-typescript: Language
 
 include::ROOT:partial$include.adoc[]
 include::partial$attributes.adoc[]
@@ -97,14 +98,14 @@ By default, the descriptor is written to `user-function.desc`, if you wish to ch
 There are two ways to create and start an Akka Serverless gRPC server. The first is to create an link:{attachmentsdir}/api/module-akkaserverless.Entity.html[`Entity`{tab-icon}, window="new"], and invoke link:{attachmentsdir}/api/module-akkaserverless.Entity.html#start[`start`{tab-icon}, window="new"] on it. This allows creating a server that serves a single entity, with the default options. We'll look at this more in the subsequent pages. Alternatively, you can use the link:{attachmentsdir}/api/module-akkaserverless.AkkaServerless.html[`AkkaServerless`{tab-icon}, window="new"] class, add one or more entities to it, and then invoke link:{attachmentsdir}/api/module-akkaserverless.AkkaServerless.html#start[`start`{tab-icon}, window="new"], like so:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$test/gettingstarted/index.js[tag=start]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -114,14 +115,14 @@ include::example$test/gettingstarted/index.ts[tag=start]
 If you created your protobuf file descriptor set at a different location to the default of `user-function.desc`, you can configure that here:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$test/gettingstarted/index.js[tag=custom-desc]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----

--- a/docs/src/modules/javascript/pages/kickstart.adoc
+++ b/docs/src/modules/javascript/pages/kickstart.adoc
@@ -1,4 +1,5 @@
 = Kickstart a Node module
+:page-supergroup-javascript-typescript: Language
 
 include::ROOT:partial$include.adoc[]
 include::partial$attributes.adoc[]
@@ -121,14 +122,14 @@ NOTE: The `lib/generated` directory contains files used by the tools. Any change
 Akka Serverless codegen creates a unit test stub for each class within `counter.test.js`. Use these stubs as a starting point to test the logic in your implementation. You can use any of the common Node.js testing tools, such as Mocha or Jest.
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,javascript]
 ----
 include::example$valueentity-counter/test/counter.test.js[]
 ----
 
-TS::
+TypeScript::
 +
 [source,typescript]
 ----
@@ -138,14 +139,14 @@ include::example$ts-valueentity-counter/test/counter.test.ts[]
 The entity used by `counter.test.js` is contained within `testkit.js`.
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,javascript]
 ----
 include::example$valueentity-counter/test/testkit.js[]
 ----
 
-TS::
+TypeScript::
 +
 [source,typescript]
 ----

--- a/docs/src/modules/javascript/pages/serialization.adoc
+++ b/docs/src/modules/javascript/pages/serialization.adoc
@@ -1,4 +1,5 @@
 = Serialization options for JavaScript services
+:page-supergroup-javascript-typescript: Language
 
 include::ROOT:partial$include.adoc[]
 include::partial$serialization.adoc[]
@@ -11,7 +12,7 @@ As a JavaScript developer, JSON is likely more familiar to you. When creating Ev
 The following example sets JSON serialization fo a snapshot:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,javascript,indent=0]
 ----
@@ -29,7 +30,7 @@ const entity = new EventSourcedEntity(
 );
 ----
 
-TS::
+TypeScript::
 +
 [source,typescript,indent=0]
 ----

--- a/docs/src/modules/javascript/pages/value-entity.adoc
+++ b/docs/src/modules/javascript/pages/value-entity.adoc
@@ -1,4 +1,5 @@
 = Implementing Value Entities in JavaScript
+:page-supergroup-javascript-typescript: Language
 
 include::ROOT:partial$include.adoc[]
 
@@ -57,14 +58,14 @@ The following code creates the Value Entity with the link:{attachmentsdir}/api/m
 * The fully qualified name of the service the Value Entity implements, `com.example.CounterService`. The `entityType` is used to namespace the state in the journal.
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js]
 ----
 include::example$valueentity-counter/src/counter.js[tag=entity-class]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts]
 ----
@@ -79,14 +80,14 @@ When passing state to Akka Serverless  the persisted data must be serialized and
 Use the `ValueEntity` link:{attachmentsdir}/api/module-akkaserverless.ValueEntity.html#lookupType[`lookupType`{tab-icon}, window="new"] helper to look up these types so we can use them later.
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js]
 ----
 include::example$valueentity-counter/src/counter.js[tag=lookup-type]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts]
 ----
@@ -100,14 +101,14 @@ An Entity must have an initial state when it is created and no state has been pe
 To create the initial state, set the link:{attachmentsdir}/api/module-akkaserverless.ValueEntity.html#initial[`initial`{tab-icon}, window="new"] callback. This takes the ID of the entity being created, and returns a new empty state, in this case, an empty counter state:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js]
 ----
 include::example$valueentity-counter/src/counter.js[tag=initial]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts]
 ----
@@ -129,14 +130,14 @@ The command handler must return a message of the same type as the output type of
 The following example shows the implementation of a `GetCurrentCounter` command handler. This command handler is a read-only command handler, it doesn't update the state, it just returns it:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js]
 ----
 include::example$valueentity-counter/src/counter.js[tag=get-current]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts]
 ----
@@ -150,14 +151,14 @@ When updating the state, a command handler MUST persist that change by calling t
 The following command handler updates the state. It also validates the command, ensuring the quantity of items added is greater than zero. Invoking link:{attachmentsdir}/api/module-akkaserverless.ValueEntity.ValueEntityCommandContext.html#fail[`fail`{tab-icon}, window="new"] fails the command. This method throws, so there's no need to explicitly throw an exception.
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js]
 ----
 include::example$valueentity-counter/src/counter.js[tag=increase]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts]
 ----
@@ -169,14 +170,14 @@ include::example$ts-valueentity-counter/src/counter.ts[tag=increase]
 A helper method for listing the components declared in the current project is provided by the code generator. It also creates the relevant code for starting all of the components:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js]
 ----
 include::example$valueentity-counter/src/index.js[tag=starting]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts]
 ----

--- a/docs/src/modules/javascript/pages/views.adoc
+++ b/docs/src/modules/javascript/pages/views.adoc
@@ -1,4 +1,5 @@
 = Implementing Views
+:page-supergroup-javascript-typescript: Language
 
 include::ROOT:partial$include.adoc[]
 
@@ -78,14 +79,14 @@ In the View implementation, register the View with Akka Serverless. In addition 
 
 .customer-value-entity-view.js
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$js-customer-registry/customer-value-entity-view.js[tag=register]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -96,14 +97,14 @@ Invoke the `addComponent` function to register the view with the service. For ex
 
 .index.js
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$js-customer-registry/index.js[tag=register]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -160,14 +161,14 @@ Implement the View by defining the functions that transform events to View state
 
 .customer-event-sourced-view.js
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$js-customer-registry/customer-event-sourced-view.js[tag=process-events]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -187,14 +188,14 @@ In the implementation, register the View with `AkkaServerless`:
 
 .customer-event-sourced-view.js
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$js-customer-registry/customer-event-sourced-view.js[tag=register]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -205,14 +206,14 @@ Invoke the `addComponent` function to register the view with the service. For ex
 
 .index.js
 [.tabset]
-JS::
+JavaScript::
 +
 [source,js,indent=0]
 ----
 include::example$js-customer-registry/index.js[tags=register-event-sourced]
 ----
 
-TS::
+TypeScript::
 +
 [source,ts,indent=0]
 ----
@@ -272,14 +273,14 @@ include::example$js-customer-registry/customer_view.proto[tag=wrap-repeated]
 View tests need to create gRPC clients for both the Entity and the View. For example:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,javascript]
 ----
 include::example$js-customer-registry/integration-test/customer-registry-test.js[tag=client]
 ----
 
-TS::
+TypeScript::
 +
 [source,typescript]
 ----
@@ -289,14 +290,14 @@ include::example$ts-customer-registry/integration-test/customer-registry-test.ts
 Since Views do not immediately update on changes, add a retry to make sure the test doesn't fail unnecessarily. For example:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,javascript]
 ----
 include::example$js-customer-registry/integration-test/customer-registry-test.js[tag=view]
 ----
 
-TS::
+TypeScript::
 +
 [source,typescript]
 ----
@@ -306,14 +307,14 @@ include::example$ts-customer-registry/integration-test/customer-registry-test.ts
 Provide some data:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,javascript]
 ----
 include::example$js-customer-registry/integration-test/customer-registry-test.js[tag=data]
 ----
 
-TS::
+TypeScript::
 +
 [source,typescript]
 ----
@@ -323,14 +324,14 @@ include::example$ts-customer-registry/integration-test/customer-registry-test.ts
 Exercise the View:
 
 [.tabset]
-JS::
+JavaScript::
 +
 [source,javascript]
 ----
 include::example$js-customer-registry/integration-test/customer-registry-test.js[tag=exercise]
 ----
 
-TS::
+TypeScript::
 +
 [source,typescript]
 ----


### PR DESCRIPTION
Add supergroup and use `JavaScript` and `TypeScript` to get tab switching for all code snippets.

See https://github.com/lightbend/akkaserverless-docs/pull/952