### PR TITLE
Use latest in npx commands

### DIFF
--- a/docs/src/modules/javascript/pages/developer-tools.adoc
+++ b/docs/src/modules/javascript/pages/developer-tools.adoc
@@ -13,7 +13,7 @@ npm::
 +
 [source,command line]
 ----
-npx @lightbend/create-akkasls-entity my-entity
+npx @lightbend/create-akkasls-entity@latest my-entity
 cd my-entity
 npm install
 npm run build
@@ -23,7 +23,7 @@ Yarn::
 +
 [source,command line]
 ----
-yarn create @lightbend/akkasls-entity my-entity
+yarn create @lightbend/akkasls-entity@latest my-entity
 cd my-entity
 yarn
 yarn build

--- a/docs/src/modules/javascript/pages/kickstart.adoc
+++ b/docs/src/modules/javascript/pages/kickstart.adoc
@@ -39,7 +39,7 @@ npm::
 --
 [source, command window, subs="attributes"]
 ----
-npx @lightbend/create-akkasls-entity my-entity
+npx @lightbend/create-akkasls-entity@latest my-entity
 ----
 --
 yarn::
@@ -47,7 +47,7 @@ yarn::
 --
 [source, command window, subs="attributes"]
 ----
-yarn create @lightbend/akkasls-entity my-entity
+yarn create @lightbend/akkasls-entity@latest my-entity
 ----
 --
 

--- a/npm-js/create-akkasls-entity/README.md
+++ b/npm-js/create-akkasls-entity/README.md
@@ -15,7 +15,7 @@ There are two templates available to select from:
 To create the initial codebase for a new entity with npm:
 
 ```sh
-npx @lightbend/create-akkasls-entity my-entity --template value-entity
+npx @lightbend/create-akkasls-entity@latest my-entity --template value-entity
 cd my-entity
 npm install
 npm run build
@@ -24,7 +24,7 @@ npm run build
 Or using Yarn:
 
 ```sh
-yarn create @lightbend/akkasls-entity my-entity --template value-entity
+yarn create @lightbend/akkasls-entity@latest my-entity --template value-entity
 cd my-entity
 yarn
 yarn build


### PR DESCRIPTION
`npx` doesn't attempt to fetch a newer version if you have already one installed.
ref: https://github.com/npm/cli/issues/2329