### PR TITLE
bump: update ssh2 dependencies (security vulnerabilities)

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -350,18 +350,18 @@
       "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw=="
     },
     "@types/ssh2": {
-      "version": "0.5.46",
-      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.46.tgz",
-      "integrity": "sha512-1pC8FHrMPYdkLoUOwTYYifnSEPzAFZRsp3JFC/vokQ+dRrVI+hDBwz0SNmQ3pL6h39OSZlPs0uCG7wKJkftnaA==",
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.48.tgz",
+      "integrity": "sha512-cmQu0gp/6RtDXe1r2xXGgi0V0TeCdueDSRMEvBX8cTRT/sSREkUpgCYZLyh+iI8Ql+VNV8Az9toQoYa/IdgHbQ==",
       "requires": {
         "@types/node": "*",
         "@types/ssh2-streams": "*"
       }
     },
     "@types/ssh2-streams": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.8.tgz",
-      "integrity": "sha512-I7gixRPUvVIyJuCEvnmhr3KvA2dC0639kKswqD4H5b4/FOcnPtNU+qWLiXdKIqqX9twUvi5j0U1mwKE5CUsrfA==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.9.tgz",
+      "integrity": "sha512-I2J9jKqfmvXLR5GomDiCoHrEJ58hAOmFrekfFqmCFd+A6gaEStvWnPykoWUwld1PNg4G5ag1LwdA+Lz1doRJqg==",
       "requires": {
         "@types/node": "*"
       }
@@ -1283,6 +1283,15 @@
         }
       }
     },
+    "cpu-features": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.2.tgz",
+      "integrity": "sha512-/2yieBqvMcRj8McNzkycjW2v3OIUOibBfd2dLEJ0nWts8NobAxwiyw9phVNS6oDL8x8tz9F7uNVFEVpJncQpeA==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.1"
+      }
+    },
     "crc-32": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
@@ -1432,16 +1441,22 @@
       }
     },
     "docker-modem": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.0.tgz",
-      "integrity": "sha512-WwFajJ8I5geZ/dDZ5FDMDA6TBkWa76xWwGIGw8uzUjNUGCN0to83wJ8Oi1AxrJTC0JBn+7fvIxUctnawtlwXeg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.3.tgz",
+      "integrity": "sha512-Tgkn2a+yiNP9FoZgMa/D9Wk+D2Db///0KOyKSYZRJa8w4+DzKyzQMkczKSdR/adQ0x46BOpeNkoyEOKjPhCzjw==",
       "requires": {
         "debug": "^4.1.1",
         "readable-stream": "^3.5.0",
         "split-ca": "^1.0.1",
-        "ssh2": "^0.8.7"
+        "ssh2": "^1.4.0"
       },
       "dependencies": {
+        "nan": {
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+          "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+          "optional": true
+        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -1451,13 +1466,24 @@
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
+        },
+        "ssh2": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.4.0.tgz",
+          "integrity": "sha512-XvXwcXKvS452DyQvCa6Ct+chpucwc/UyxgliYz+rWXJ3jDHdtBb9xgmxJdMmnIn5bpgGAEV3KaEsH98ZGPHqwg==",
+          "requires": {
+            "asn1": "^0.2.4",
+            "bcrypt-pbkdf": "^1.0.2",
+            "cpu-features": "0.0.2",
+            "nan": "^2.15.0"
+          }
         }
       }
     },
     "dockerode": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.0.tgz",
-      "integrity": "sha512-St08lfOjpYCOXEM8XA0VLu3B3hRjtddODphNW5GFoA0AS3JHgoPQKOz0Qmdzg3P+hUPxhb02g1o1Cu1G+U3lRg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.1.tgz",
+      "integrity": "sha512-AS2mr8Lp122aa5n6d99HkuTNdRV1wkkhHwBdcnY6V0+28D3DSYwhxAk85/mM9XwD3RMliTxyr63iuvn5ZblFYQ==",
       "requires": {
         "docker-modem": "^3.0.0",
         "tar-fs": "~2.0.1"
@@ -3209,7 +3235,6 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
       "optional": true
     },
     "nanomatch": {
@@ -4413,30 +4438,31 @@
       "dev": true
     },
     "ssh-remote-port-forward": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.3.tgz",
-      "integrity": "sha512-PJ6qGFmB6n0iMCQIp+qzx8qVUE5cgacopvEh63t3NJjEQHOaza/JT9zywmmVlaol/eGtCmpvBXx2A03ih1Y+xg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz",
+      "integrity": "sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==",
       "requires": {
-        "@types/ssh2": "^0.5.45",
-        "ssh2": "^0.8.9"
+        "@types/ssh2": "^0.5.48",
+        "ssh2": "^1.4.0"
       }
     },
     "ssh2": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
-      "integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.4.0.tgz",
+      "integrity": "sha512-XvXwcXKvS452DyQvCa6Ct+chpucwc/UyxgliYz+rWXJ3jDHdtBb9xgmxJdMmnIn5bpgGAEV3KaEsH98ZGPHqwg==",
       "requires": {
-        "ssh2-streams": "~0.4.10"
-      }
-    },
-    "ssh2-streams": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
-      "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
-      "requires": {
-        "asn1": "~0.2.0",
+        "asn1": "^0.2.4",
         "bcrypt-pbkdf": "^1.0.2",
-        "streamsearch": "~0.1.2"
+        "cpu-features": "0.0.2",
+        "nan": "^2.15.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+          "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+          "optional": true
+        }
       }
     },
     "static-extend": {
@@ -4504,11 +4530,6 @@
       "requires": {
         "any-promise": "^1.1.0"
       }
-    },
-    "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "string-width": {
       "version": "1.0.2",


### PR DESCRIPTION
Updates for the vulnerability check:

```
                       === npm audit security report ===                        
                                                                                
# Run  npm update dockerode --depth 2  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ OS Command Injection in ssh2                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ ssh2                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ testcontainers                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ testcontainers > dockerode > docker-modem > ssh2             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/advisories/GHSA-652h-xwhf-q4h6            │
└───────────────┴──────────────────────────────────────────────────────────────┘


# Run  npm update ssh-remote-port-forward --depth 2  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ OS Command Injection in ssh2                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ ssh2                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ testcontainers                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ testcontainers > ssh-remote-port-forward > ssh2              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/advisories/GHSA-652h-xwhf-q4h6            │
└───────────────┴──────────────────────────────────────────────────────────────┘


found 2 high severity vulnerabilities in 169 scanned packages
```