### PR TITLE
feat: reinstate metadata map and cloudevents

### DIFF
--- a/sdk/src/cloudevent.ts
+++ b/sdk/src/cloudevent.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Metadata } from './metadata';
+
+/**
+ * CloudEvent data.
+ */
+export class Cloudevent {
+  readonly metadata: Metadata;
+
+  constructor(metadata: Metadata) {
+    this.metadata = metadata;
+  }
+
+  get specversion(): string | undefined {
+    return this.getString('ce-specversion');
+  }
+
+  get id(): string | undefined {
+    return this.getString('ce-id');
+  }
+
+  set id(id: string | undefined) {
+    if (id === undefined) {
+      this.metadata.delete('ce-id');
+    } else {
+      this.metadata.asMap['ce-id'] = id;
+    }
+  }
+
+  get source(): string | undefined {
+    return this.getString('ce-source');
+  }
+
+  set source(source: string | undefined) {
+    if (source === undefined) {
+      this.metadata.delete('ce-source');
+    } else {
+      this.metadata.asMap['ce-source'] = source;
+    }
+  }
+
+  get type(): string | undefined {
+    return this.getString('ce-type');
+  }
+
+  set type(type: string | undefined) {
+    if (type === undefined) {
+      this.metadata.delete('ce-type');
+    } else {
+      this.metadata.asMap['ce-type'] = type;
+    }
+  }
+
+  get datacontenttype(): string | undefined {
+    return this.getString('Content-Type');
+  }
+
+  set datacontenttype(datacontenttype: string | undefined) {
+    if (datacontenttype === undefined) {
+      this.metadata.delete('Content-Type');
+    } else {
+      this.metadata.asMap['Content-Type'] = datacontenttype;
+    }
+  }
+
+  get dataschema(): string | undefined {
+    return this.getString('ce-dataschema');
+  }
+
+  set dataschema(dataschema: string | undefined) {
+    if (dataschema === undefined) {
+      this.metadata.delete('ce-dataschema');
+    } else {
+      this.metadata.asMap['ce-subject'] = dataschema;
+    }
+  }
+
+  get subject(): string | undefined {
+    return this.getString('ce-subject');
+  }
+
+  set subject(subject: string | undefined) {
+    if (subject === undefined) {
+      this.metadata.delete('ce-subject');
+    } else {
+      this.metadata.asMap['ce-subject'] = subject;
+    }
+  }
+
+  get time(): Date | undefined {
+    const value = this.metadata.asMap['ce-time'];
+    if (typeof value === 'string') {
+      try {
+        return new Date(Date.parse(value));
+      } catch (e) {
+        return undefined;
+      }
+    }
+    return undefined;
+  }
+
+  set time(time: Date | undefined) {
+    if (time === undefined) {
+      this.metadata.delete('ce-time');
+    } else {
+      this.metadata.asMap['ce-time'] = (time as Date).toISOString();
+    }
+  }
+
+  private getString(name: string): string | undefined {
+    const value = this.metadata.asMap[name];
+    if (typeof value === 'string') {
+      return value as string;
+    }
+    return undefined;
+  }
+}

--- a/sdk/test/metadata.test.ts
+++ b/sdk/test/metadata.test.ts
@@ -97,15 +97,53 @@ describe('Metadata', () => {
     expect(res.length).to.be.equal(0);
   });
 
-  it('should return the subject', () => {
+  it('allows access to Cloudevent subject', () => {
     // Arrange
     const meta = new Metadata();
     meta.set('ce-subject', 'hello1');
 
     // Act
-    const res = meta.getSubject();
+    const res = meta.cloudevent.subject;
 
     // Assert
     expect(res).to.be.equal('hello1');
+  });
+
+  it('should make string entries accessible as a map', () => {
+    const meta = new Metadata();
+    meta.set('foo', 'string');
+    meta.set('foo', new Buffer('bytes'));
+    expect(meta.asMap.foo).to.be.equal('string');
+  });
+
+  it('should make byte entries accessible as a map', () => {
+    const meta = new Metadata();
+    meta.set('foo', new Buffer('bytes'));
+    meta.set('foo', 'string');
+    expect((meta.asMap.foo as Buffer).toString()).to.be.equal('bytes');
+  });
+
+  it('changes to the map should be reflected in the metadata', () => {
+    const meta = new Metadata();
+    meta.set('foo', 'string');
+    meta.set('foo', new Buffer('bytes'));
+    meta.asMap.foo = 'new string';
+    expect(meta.entries.length).to.be.equal(1);
+    expect(meta.entries[0].stringValue).to.be.equal('new string');
+  });
+
+  it('allows deleting properties from the map', () => {
+    const meta = new Metadata();
+    meta.set('foo', 'string');
+    meta.set('foo', new Buffer('bytes'));
+    delete meta.asMap.foo;
+    expect(meta.entries.length).to.be.equal(0);
+  });
+
+  it('correctly handles Cloudevent times', () => {
+    const now = new Date();
+    const meta = new Metadata();
+    meta.set('ce-time', now.toISOString());
+    expect((meta.cloudevent.time as Date).getTime()).to.be.equal(now.getTime());
   });
 });


### PR DESCRIPTION
When I originally wrote the JavaScript API, the important thing was that there was a very convenient way to access properties where you didn't have to deal with the fact that there could be multiple values for each property (beacuse usually there aren't). So I had a way of using the metadata as a plain JavaScript object/map. This API was not ported to TypeScript, which leaves the user experience somewhat lacking in my opinion.

This reinstates that.

Also, this reinstates the CloudEvents API which was inexplicably removed in #59 - it's always been a feature goal of Akka Serverless to support cloud standards, and CloudEvents is an important one of those considering we deal with events a lot.