### PR TITLE
Typo in proto.adoc

### DIFF
--- a/docs/src/modules/javascript/pages/proto.adoc
+++ b/docs/src/modules/javascript/pages/proto.adoc
@@ -153,6 +153,6 @@ In the example below, the optional transcoding of the service to bind the variou
 ----
 include::example$js-valueentity-shopping-cart/proto/shoppingcart_api.proto[tag=proto_service]
 ----
-<1> This extra annotation specifies that you can call this endpoint using the POST method with the URI `/cart/\{user_id}/items/add`, where `\{user_id}` is the actual user id we want the cart for.
+<1> This extra annotation specifies that you can call this endpoint using the POST method with the URI `/cart/\{cart_id}/items/add`, where `\{cart_id}` is the actual id of the cart you want to use.
 <2> A URL that accepts a POST method to remove a line item.
 <3> A more complex example where the first `get` URI retrieves the whole cart, and the second retrieves the items in the cart.


### PR DESCRIPTION
No issue.  Just a fix for a small typo.

The doc renders the example with footnote 1 referring to the third line of:
```
  rpc AddItem (AddLineItem) returns (google.protobuf.Empty) {
    option (google.api.http) = {
            post: "/cart/{cart_id}/items/add"
            body: "*"
        };
  }
```
But the footnote says:
> This extra annotation specifies that you can call this endpoint using the POST method with the URI /cart/{user_id}/items/add, where {user_id} is the actual user id we want the cart for.


