### PR TITLE
fix: use "static-module" instead of "static" only target

### DIFF
--- a/npm-js/akkasls-scripts/bin/akkasls-scripts.js
+++ b/npm-js/akkasls-scripts/bin/akkasls-scripts.js
@@ -61,7 +61,7 @@ const scriptHandlers = {
     runOrFail(
       'Building static Javascript definitions from proto',
       path.resolve('node_modules', '.bin', 'pbjs'),
-      [...protoFiles, '-t', 'static', '-o', protoJs],
+      [...protoFiles, '-t', 'static-module', '-o', protoJs],
       { shell: true },
     );
 


### PR DESCRIPTION
References https://github.com/lightbend/akkaserverless/issues/6192

```
 -t, --target     Specifies the target format. Also accepts a path to require a custom target.

                   json          JSON representation
                   json-module   JSON representation as a module
                   proto2        Protocol Buffers, Version 2
                   proto3        Protocol Buffers, Version 3
                   static        Static code without reflection (non-functional on its own)
                   static-module Static code without reflection as a module
```

Source: https://www.npmjs.com/package/protobufjs#pbjs-for-javascript