### PR TITLE
feat: allow specifying a custom status when failing

### DIFF
--- a/docs/src/modules/javascript/examples/action/src/action.js
+++ b/docs/src/modules/javascript/examples/action/src/action.js
@@ -41,7 +41,10 @@ function processStreamed(context) {
 function respondWith(response, context) {
   // need to accumulate effects, before replying, forwarding, or failing
   response.effects.forEach(effect => context.effect(two.service.methods.Call, { id: effect.id }, effect.synchronous));
-  if (response.fail) context.fail(response.fail);
+  if (response.fail) context.fail(
+      response.fail,
+      9, // optional parameter, sets the gRPC status code to 9 - FAILED_PRECONDITION
+  );
   else if (response.forward) context.forward(two.service.methods.Call, { id: response.forward });
   else if (response.reply) context.write(Response.create({ message: response.reply }));
   else context.write(); // empty message

--- a/docs/src/modules/javascript/examples/action/src/action.ts
+++ b/docs/src/modules/javascript/examples/action/src/action.ts
@@ -97,7 +97,10 @@ function createReplyForGroup(group: ProcessGroup): replies.Reply {
           step.effect.synchronous || false
       );
     } else if (step.fail) {
-      reply = replies.failure(step.fail.message || "");
+      reply = replies.failure(
+          step.fail.message || "",
+          replies.GrpcStatus.FailedPrecondition, // Optional parameter, sets the gRPC code
+      );
     }
   });
   return reply;

--- a/docs/src/modules/javascript/examples/test/eventsourced/shoppingcart.js
+++ b/docs/src/modules/javascript/examples/test/eventsourced/shoppingcart.js
@@ -47,7 +47,10 @@ function getCart(request, cart) {
 // tag::add-item[]
 function addItem(addItem, cart, ctx) {
     if (addItem.quantity < 1) {
-        ctx.fail("Quantity for item " + addItem.productId + " must be greater than zero.");
+        ctx.fail(
+            "Quantity for item " + addItem.productId + " must be greater than zero.",
+            3, // optional parameter, sets the gRPC status code to 3 - INVALID_ARGUMENT
+        );
     } else {
         const itemAdded = ItemAdded.create({
             item: {

--- a/docs/src/modules/javascript/examples/test/eventsourced/shoppingcart.ts
+++ b/docs/src/modules/javascript/examples/test/eventsourced/shoppingcart.ts
@@ -66,7 +66,8 @@ function addItem(
 ): replies.Reply {
     if (addItem.quantity < 1) {
         return replies.failure(
-            "Quantity for item " + addItem.productId + " must be greater than zero."
+            "Quantity for item " + addItem.productId + " must be greater than zero.",
+            replies.GrpcStatus.InvalidArgument, // optional parameter, customise gRPC code
         );
     }
 

--- a/docs/src/modules/javascript/examples/value-entity/src/shoppingcart.js
+++ b/docs/src/modules/javascript/examples/value-entity/src/shoppingcart.js
@@ -35,7 +35,10 @@ function addItem(addItem, cart, ctx) {
   // Validation:
   // Make sure that it is not possible to add negative quantities
   if (addItem.quantity < 1) {
-    ctx.fail("Quantity for item " + addItem.productId + " must be greater than zero.");
+    ctx.fail(
+        "Quantity for item " + addItem.productId + " must be greater than zero.",
+        3, // optional parameter, sets the gRPC status code to 3 - INVALID_ARGUMENT
+    );
   } else {
     // If there is an existing item with that product id, we need to increment its quantity.
     const existing = cart.items.find(item => {

--- a/docs/src/modules/javascript/examples/value-entity/src/shoppingcart.ts
+++ b/docs/src/modules/javascript/examples/value-entity/src/shoppingcart.ts
@@ -53,7 +53,8 @@ function addItem(
   // Make sure that it is not possible to add negative quantities
   if (addItem.quantity < 1) {
     return replies.failure(
-        "Quantity for item " + addItem.productId + " must be greater than zero."
+        "Quantity for item " + addItem.productId + " must be greater than zero.",
+        replies.GrpcStatus.InvalidArgument, // optional parameter, customise gRPC code
     );
   } else {
     // If there is an existing item with that product id, we need to increment its quantity.

--- a/samples/ts/ts-valueentity-counter/test/testkit.ts
+++ b/samples/ts/ts-valueentity-counter/test/testkit.ts
@@ -70,7 +70,9 @@ export class MockValueEntity<S extends object> {
     } else if (ctx.updatedState) {
       this.state = ctx.updatedState;
     }
-    this.error = failure;
+    if (failure !== undefined) {
+      this.error = failure.description;
+    }
 
     return grpcMethod.responseDeserialize(
       grpcMethod.responseSerialize(message)

--- a/sdk/integration-test/integration-testkit-test.js
+++ b/sdk/integration-test/integration-testkit-test.js
@@ -31,7 +31,7 @@ action.commandHandlers = {
     ctx.end();
   },
   Fail: (input, ctx) => {
-    ctx.fail("some-error", 6);
+    ctx.fail('some-error', 6);
   },
 };
 
@@ -58,7 +58,7 @@ value_entity.commandHandlers = {
     });
   },
   Fail: (input, state, ctx) => {
-    ctx.fail("some-error", 6);
+    ctx.fail('some-error', 6);
   },
 };
 
@@ -90,7 +90,7 @@ entity.setBehavior((e) => {
         });
       },
       Fail: (input, state, ctx) => {
-        ctx.fail("some-error", 6);
+        ctx.fail('some-error', 6);
       },
     },
     eventHandlers: {},
@@ -125,17 +125,14 @@ describe('The AkkaServerless IntegrationTestkit', function () {
   });
 
   it('should allow actions to fail with custom code', (done) => {
-    testkit.clients.ExampleService.Fail(
-        { field: 'hello' },
-        (err, msg) => {
-          err.should.not.be.undefined;
-          // Unfortunately, this appears to be the only way the JS library offers to read the error description,
-          // by reading this unspecified message string.
-          err.message.should.be.eq('6 ALREADY_EXISTS: some-error');
-          err.code.should.be.eq(6);
-          done();
-        },
-    );
+    testkit.clients.ExampleService.Fail({ field: 'hello' }, (err, msg) => {
+      err.should.not.be.undefined;
+      // Unfortunately, this appears to be the only way the JS library offers to read the error description,
+      // by reading this unspecified message string.
+      err.message.should.be.eq('6 ALREADY_EXISTS: some-error');
+      err.code.should.be.eq(6);
+      done();
+    });
   });
 
   it('should handle value entities sync handlers', (done) => {
@@ -159,15 +156,12 @@ describe('The AkkaServerless IntegrationTestkit', function () {
   });
 
   it('should allow value entities to fail with custom code', (done) => {
-    testkit.clients.ExampleServiceTwo.Fail(
-        { field: 'hello' },
-        (err, msg) => {
-          err.should.not.be.undefined;
-          err.message.should.be.eq('6 ALREADY_EXISTS: some-error');
-          err.code.should.be.eq(6);
-          done();
-        },
-    );
+    testkit.clients.ExampleServiceTwo.Fail({ field: 'hello' }, (err, msg) => {
+      err.should.not.be.undefined;
+      err.message.should.be.eq('6 ALREADY_EXISTS: some-error');
+      err.code.should.be.eq(6);
+      done();
+    });
   });
 
   it('should handle event sourced entities sync handlers', (done) => {
@@ -191,15 +185,11 @@ describe('The AkkaServerless IntegrationTestkit', function () {
   });
 
   it('should allow event sourced entities to fail with custom code', (done) => {
-    testkit.clients.ExampleServiceThree.Fail(
-        { field: 'hello' },
-        (err, msg) => {
-          err.should.not.be.undefined;
-          err.message.should.be.eq('6 ALREADY_EXISTS: some-error');
-          err.code.should.be.eq(6);
-          done();
-        },
-    );
+    testkit.clients.ExampleServiceThree.Fail({ field: 'hello' }, (err, msg) => {
+      err.should.not.be.undefined;
+      err.message.should.be.eq('6 ALREADY_EXISTS: some-error');
+      err.code.should.be.eq(6);
+      done();
+    });
   });
-
 });

--- a/sdk/src/action-support.js
+++ b/sdk/src/action-support.js
@@ -608,10 +608,10 @@ class ActionHandler {
     };
     if (grpcStatus !== undefined) {
       if (grpcStatus === 0) {
-        throw new Error("gRPC failure status code must not be OK")
+        throw new Error('gRPC failure status code must not be OK');
       }
       if (grpcStatus < 0 || grpcStatus > 16) {
-        throw new Error("Invalid gRPC status code: " + grpcStatus)
+        throw new Error('Invalid gRPC status code: ' + grpcStatus);
       }
       failure.grpcStatusCode = grpcStatus;
     }

--- a/sdk/src/command-helper.js
+++ b/sdk/src/command-helper.js
@@ -84,7 +84,10 @@ class CommandHelper {
 
     if (!this.service.methods.hasOwnProperty(command.name)) {
       ctx.commandDebug("Command '%s' unknown", command.name);
-      return errorReply('Unknown command named ' + command.name, 12 /* unimplemented */);
+      return errorReply(
+        'Unknown command named ' + command.name,
+        12 /* unimplemented */,
+      );
     } else {
       try {
         const grpcMethod = this.service.methods[command.name];
@@ -155,9 +158,9 @@ class CommandHelper {
     const failure = {
       commandId: ctx.commandId,
       description: msg,
-    }
+    };
     if (status !== undefined) {
-      failure.grpcStatusCode = status
+      failure.grpcStatusCode = status;
     }
     return {
       reply: {
@@ -173,11 +176,21 @@ class CommandHelper {
     const userReply = await this.invoke(handler, ctx);
 
     if (ctx.error !== null) {
-      return this.errorReply(ctx.error.message, ctx.error.grpcStatus, ctx, desc);
+      return this.errorReply(
+        ctx.error.message,
+        ctx.error.grpcStatus,
+        ctx,
+        desc,
+      );
     } else if (userReply instanceof Reply) {
       if (userReply.failure) {
         // handle failure with a separate write to make sure we don't write back events etc
-        return this.errorReply(userReply.failure.description, userReply.failure.status, ctx, desc);
+        return this.errorReply(
+          userReply.failure.description,
+          userReply.failure.status,
+          ctx,
+          desc,
+        );
       } else {
         // effects need to go first to end up in reply
         // note that we amend the ctx.reply to get events etc passed along from the entities

--- a/sdk/src/context-failure.ts
+++ b/sdk/src/context-failure.ts
@@ -17,12 +17,22 @@
 export class ContextFailure extends Error {
   readonly name: string = 'ContextFailure';
   readonly msg: string;
+  readonly grpcStatus?: number;
 
-  constructor(msg: string) {
+  constructor(msg: string, grpcStatus?: number) {
     super(msg);
     this.msg = msg;
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ContextFailure);
+    }
+    if (grpcStatus !== undefined) {
+      if (grpcStatus === 0) {
+        throw new Error("gRPC failure status code must not be OK")
+      }
+      if (grpcStatus < 0 || grpcStatus > 16) {
+        throw new Error("Invalid gRPC status code: " + grpcStatus)
+      }
+      this.grpcStatus = grpcStatus;
     }
   }
 }

--- a/sdk/src/context-failure.ts
+++ b/sdk/src/context-failure.ts
@@ -27,10 +27,10 @@ export class ContextFailure extends Error {
     }
     if (grpcStatus !== undefined) {
       if (grpcStatus === 0) {
-        throw new Error("gRPC failure status code must not be OK")
+        throw new Error('gRPC failure status code must not be OK');
       }
       if (grpcStatus < 0 || grpcStatus > 16) {
-        throw new Error("Invalid gRPC status code: " + grpcStatus)
+        throw new Error('Invalid gRPC status code: ' + grpcStatus);
       }
       this.grpcStatus = grpcStatus;
     }

--- a/sdk/src/reply.ts
+++ b/sdk/src/reply.ts
@@ -247,16 +247,13 @@ export function noReply(): Reply {
 }
 
 export class Failure {
-  constructor(
-      private description: string,
-      private status?: GrpcStatus
-  ) {
+  constructor(private description: string, private status?: GrpcStatus) {
     if (status !== undefined) {
       if (status === GrpcStatus.Ok) {
-        throw new Error("gRPC failure status code must not be OK")
+        throw new Error('gRPC failure status code must not be OK');
       }
       if (status < 0 || status > 16) {
-        throw new Error("Invalid gRPC status code: " + status)
+        throw new Error('Invalid gRPC status code: ' + status);
       }
     }
   }
@@ -268,7 +265,6 @@ export class Failure {
   getStatus(): GrpcStatus | undefined {
     return this.status;
   }
-
 }
 
 /**
@@ -291,5 +287,5 @@ export enum GrpcStatus {
   Internal = 13,
   Unavailable = 14,
   DataLoss = 15,
-  Unauthenticated = 16
+  Unauthenticated = 16,
 }

--- a/sdk/src/reply.ts
+++ b/sdk/src/reply.ts
@@ -44,7 +44,7 @@ export class Reply {
     private message?: any,
     private metadata?: Metadata,
     private forward?: Reply,
-    private failure?: string,
+    private failure?: Failure,
     private effects: Effect[] = [],
   ) {}
 
@@ -120,20 +120,21 @@ export class Reply {
   }
 
   /**
-   * @returns the failure description
+   * @returns the failure
    */
-  getFailure(): string | undefined {
+  getFailure(): Failure | undefined {
     return this.failure;
   }
 
   /**
    * Make this a failure reply.
    *
-   * @param failure - the failure description
+   * @param description - the failure description
+   * @param status - the status code to fail with, defaults to Unknown.
    * @returns the updated reply
    */
-  setFailure(failure: string): Reply {
-    this.failure = failure;
+  setFailure(description: string, status?: GrpcStatus): Reply {
+    this.failure = new Failure(description, status);
     return this;
   }
 
@@ -226,10 +227,11 @@ export function forward(
  * Create a failure reply.
  *
  * @param description - description of the failure
+ * @param status - the GRPC status, defaults to Unknown
  * @return a failure reply
  */
-export function failure(description: string): Reply {
-  const reply = new Reply().setFailure(description);
+export function failure(description: string, status?: GrpcStatus): Reply {
+  const reply = new Reply().setFailure(description, status);
   return reply;
 }
 
@@ -242,4 +244,52 @@ export function failure(description: string): Reply {
  */
 export function noReply(): Reply {
   return new Reply();
+}
+
+export class Failure {
+  constructor(
+      private description: string,
+      private status?: GrpcStatus
+  ) {
+    if (status !== undefined) {
+      if (status === GrpcStatus.Ok) {
+        throw new Error("gRPC failure status code must not be OK")
+      }
+      if (status < 0 || status > 16) {
+        throw new Error("Invalid gRPC status code: " + status)
+      }
+    }
+  }
+
+  getDescription(): string {
+    return this.description;
+  }
+
+  getStatus(): GrpcStatus | undefined {
+    return this.status;
+  }
+
+}
+
+/**
+ * The GRPC status codes.
+ */
+export enum GrpcStatus {
+  Ok = 0,
+  Cancelled = 1,
+  Unknown = 2,
+  InvalidArgument = 3,
+  DeadlineExceeded = 4,
+  NotFound = 5,
+  AlreadyExists = 6,
+  PermissionDenied = 7,
+  ResourceExhausted = 8,
+  FailedPrecondition = 9,
+  Aborted = 10,
+  OutOfRange = 11,
+  Unimplemented = 12,
+  Internal = 13,
+  Unavailable = 14,
+  DataLoss = 15,
+  Unauthenticated = 16
 }

--- a/sdk/test/example.proto
+++ b/sdk/test/example.proto
@@ -42,14 +42,17 @@ service ExampleService {
     rpc DoSomething(In) returns (Out);
     rpc StreamSomething(In) returns (stream Out);
     rpc PublishJsonToTopic(In) returns (google.protobuf.Any);
+    rpc Fail(In) returns (Out);
 }
 
 service ExampleServiceTwo {
     rpc DoSomethingOne(In) returns (Out);
     rpc DoSomethingTwo(In) returns (Out);
+    rpc Fail(In) returns (Out);
 }
 
 service ExampleServiceThree {
     rpc DoSomethingOne(In) returns (Out);
     rpc DoSomethingTwo(In) returns (Out);
+    rpc Fail(In) returns (Out);
 }

--- a/sdk/test/reply.test.ts
+++ b/sdk/test/reply.test.ts
@@ -40,11 +40,29 @@ describe('Replies', () => {
     expect(reply.getMessage()).to.be.undefined;
     expect(reply.getMetadata()).to.be.undefined;
     expect(reply.getForward()).to.be.undefined;
-    expect(reply.getFailure()).to.be.eq('my-msg');
     expect(reply.getEffects()).to.be.empty;
+
+    expect(reply.getFailure()).to.not.be.undefined;
+    expect(reply.getFailure()?.getDescription()).to.be.eq('my-msg');
+    expect(reply.getFailure()?.getStatus()).to.be.undefined;
   });
 
-  it('should create a failure Reply', () => {
+  it('should create a failure Reply with status', () => {
+    const reply = replies.failure('my-msg', replies.GrpcStatus.AlreadyExists);
+
+    expect(reply.isEmpty()).to.be.false;
+    expect(reply.getMethod()).to.be.undefined;
+    expect(reply.getMessage()).to.be.undefined;
+    expect(reply.getMetadata()).to.be.undefined;
+    expect(reply.getForward()).to.be.undefined;
+    expect(reply.getEffects()).to.be.empty;
+
+    expect(reply.getFailure()).to.not.be.undefined;
+    expect(reply.getFailure()?.getDescription()).to.be.eq('my-msg');
+    expect(reply.getFailure()?.getStatus()).to.be.eq(replies.GrpcStatus.AlreadyExists);
+  });
+
+  it('should create a forward Reply', () => {
     // Arrange
     const reply = replies.forward(
       new protobuf.Method('my-method', 'rpc', 'my-request', 'my-response'),

--- a/sdk/test/reply.test.ts
+++ b/sdk/test/reply.test.ts
@@ -59,7 +59,9 @@ describe('Replies', () => {
 
     expect(reply.getFailure()).to.not.be.undefined;
     expect(reply.getFailure()?.getDescription()).to.be.eq('my-msg');
-    expect(reply.getFailure()?.getStatus()).to.be.eq(replies.GrpcStatus.AlreadyExists);
+    expect(reply.getFailure()?.getStatus()).to.be.eq(
+      replies.GrpcStatus.AlreadyExists,
+    );
   });
 
   it('should create a forward Reply', () => {


### PR DESCRIPTION
This allows setting a custom status when failing, by adding an optional status parameter to the `ctx.fail()` and `replies.failure()` methods.