### PR TITLE
fix: metadata export and default empty entries

### DIFF
--- a/sdk/index.js
+++ b/sdk/index.js
@@ -27,7 +27,7 @@ module.exports.replicatedentity = require('./src/replicated-entity');
 module.exports.ReplicatedWriteConsistency =
   require('./src/akkaserverless').ReplicatedWriteConsistency;
 module.exports.Action = require('./src/action');
-module.exports.Metadata = require('./src/metadata');
+module.exports.Metadata = require('./src/metadata').Metadata;
 module.exports.IntegrationTestkit =
   require('./src/integration-testkit').IntegrationTestkit;
 module.exports.View = require('./src/view');

--- a/sdk/src/metadata.jsdoc
+++ b/sdk/src/metadata.jsdoc
@@ -39,7 +39,7 @@
  * a string using toString.
  *
  * @class module:akkaserverless.Metadata
- * @param {module:akkaserverless.MetadataEntry[]} entries The list of entries
+ * @param {module:akkaserverless.MetadataEntry[]} [entries=[]] The list of entries
  */
 
 /**

--- a/sdk/src/view-support.js
+++ b/sdk/src/view-support.js
@@ -88,7 +88,7 @@ module.exports = class ViewServices {
             try {
               const anySupport = new AnySupport(service.root),
                 metadata = new Metadata(
-                  receiveEvent.metada ? receiveEvent.metadata.entries : [],
+                  receiveEvent.metadata ? receiveEvent.metadata.entries : [],
                 ),
                 payload = anySupport.deserialize(receiveEvent.payload),
                 existingState = receiveEvent.bySubjectLookupResult


### PR DESCRIPTION
The metadata module was being exported in place of just the Metadata class. Also make the entries parameter optional with default empty array in the jsdoc type declaration.

Metadata tests import directly from the source file, and Metadata is not used in the samples (which do use the SDK), so not currently covered by tests. Suggests that being able to import the SDK exports in the tests would be useful — these go through some processing though, given the current setup. Could also extend a sample to make use of metadata. Just manually verified for now.