### PR TITLE
Update js-valueentity-shopping-cart version to 0.0.4

### DIFF
--- a/samples/js/js-valueentity-shopping-cart/package.json
+++ b/samples/js/js-valueentity-shopping-cart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-valueentity-shopping-cart",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "engines": {
     "node": ">=13.0.0",


### PR DESCRIPTION
0.0.3 is still on the old protocol, might be nice to
have them separate