### PR TITLE
fix: Status code was not accessible from typescript #284

### DIFF
--- a/sdk/index.js
+++ b/sdk/index.js
@@ -34,3 +34,4 @@ module.exports.View = require('./src/view');
 module.exports.replies = require('./src/reply');
 module.exports.settings = require('./settings');
 module.exports.GrpcUtil = require('./src/grpc-util').GrpcUtil;
+module.exports.GrpcStatus = require('./src/akkaserverless').GrpcStatus;

--- a/sdk/src/akkaserverless.jsdoc
+++ b/sdk/src/akkaserverless.jsdoc
@@ -99,3 +99,28 @@
  *                             distributed to remaining replicas in the background.
  * @property {number} ALL Updates will be written immediately to all replicas.
  */
+
+/**
+ * The GRPC status codes.
+ *
+ * @readonly
+ * @name module:akkaserverless.GrpcStatus
+ * @enum
+ * @property [Ok = 0]
+ * @property [Cancelled = 1]
+ * @property [Unknown = 2]
+ * @property [InvalidArgument = 3]
+ * @property [DeadlineExceeded = 4]
+ * @property [NotFound = 5]
+ * @property [AlreadyExists = 6]
+ * @property [PermissionDenied = 7]
+ * @property [ResourceExhausted = 8]
+ * @property [FailedPrecondition = 9]
+ * @property [Aborted = 10]
+ * @property [OutOfRange = 11]
+ * @property [Unimplemented = 12]
+ * @property [Internal = 13]
+ * @property [Unavailable = 14]
+ * @property [DataLoss = 15]
+ * @property [Unauthenticated = 16]
+ */

--- a/sdk/src/akkaserverless.ts
+++ b/sdk/src/akkaserverless.ts
@@ -571,3 +571,26 @@ export class AkkaServerless {
     }
   }
 }
+
+/**
+ * The GRPC status codes.
+ */
+export enum GrpcStatus {
+  Ok = 0,
+  Cancelled = 1,
+  Unknown = 2,
+  InvalidArgument = 3,
+  DeadlineExceeded = 4,
+  NotFound = 5,
+  AlreadyExists = 6,
+  PermissionDenied = 7,
+  ResourceExhausted = 8,
+  FailedPrecondition = 9,
+  Aborted = 10,
+  OutOfRange = 11,
+  Unimplemented = 12,
+  Internal = 13,
+  Unavailable = 14,
+  DataLoss = 15,
+  Unauthenticated = 16,
+}

--- a/sdk/src/reply.jsdoc
+++ b/sdk/src/reply.jsdoc
@@ -91,7 +91,7 @@
 
 /**
  * @function module:akkaserverless.replies.Reply#getFailure
- * @returns {string|undefined} The failure description.
+ * @returns {module:akkaserverless.replies.Failure|undefined}
  */
 
 /**
@@ -99,6 +99,7 @@
  *
  * @function module:akkaserverless.replies.Reply#setFailure
  * @param {string} failure The failure description.
+ * @param {module:akkaserverless.GrpcStatus} [status] the status code to fail with, defaults to Unknown.
  * @returns {module:akkaserverless.replies.Reply} The updated reply.
  */
 
@@ -157,6 +158,7 @@
  *
  * @function module:akkaserverless.replies~failure
  * @param {string} description A description of the failure.
+ * @param {module:akkaserverless.GrpcStatus} [status] - the GRPC status, defaults to Unknown
  * @return {module:akkaserverless.replies.Reply} A failure reply.
  */
 
@@ -167,4 +169,18 @@
  *
  * @function module:akkaserverless.replies~noReply
  * @return {module:akkaserverless.replies.Reply} An empty reply.
+ */
+
+/**
+ * @class module:akkaserverless.replies.Failure
+ */
+
+/**
+ * @function module:akkaserverless.replies.Failure#getDescription
+ * @returns {string}
+ */
+
+/**
+ * @function module:akkaserverless.replies.Failure#getStatus
+ * @returns {module:akkaserverless.GrpcStatus|undefined}
  */

--- a/sdk/src/reply.ts
+++ b/sdk/src/reply.ts
@@ -16,6 +16,9 @@
 
 import { Method } from 'protobufjs';
 import { Metadata } from './metadata';
+import { GrpcStatus } from './akkaserverless';
+
+// Note that there is a parallel reply.jsdoc that needs to be changed for API changes here to be visible
 
 /**
  * Side effect for a reply.
@@ -265,27 +268,4 @@ export class Failure {
   getStatus(): GrpcStatus | undefined {
     return this.status;
   }
-}
-
-/**
- * The GRPC status codes.
- */
-export enum GrpcStatus {
-  Ok = 0,
-  Cancelled = 1,
-  Unknown = 2,
-  InvalidArgument = 3,
-  DeadlineExceeded = 4,
-  NotFound = 5,
-  AlreadyExists = 6,
-  PermissionDenied = 7,
-  ResourceExhausted = 8,
-  FailedPrecondition = 9,
-  Aborted = 10,
-  OutOfRange = 11,
-  Unimplemented = 12,
-  Internal = 13,
-  Unavailable = 14,
-  DataLoss = 15,
-  Unauthenticated = 16,
 }

--- a/sdk/test/reply.test.ts
+++ b/sdk/test/reply.test.ts
@@ -18,6 +18,7 @@ import { expect } from 'chai';
 import protobuf from 'protobufjs';
 import { Metadata } from '../src/metadata';
 import * as replies from '../src/reply';
+import { GrpcStatus } from '../src/akkaserverless';
 
 describe('Replies', () => {
   it('should create an empty Reply', () => {
@@ -48,7 +49,7 @@ describe('Replies', () => {
   });
 
   it('should create a failure Reply with status', () => {
-    const reply = replies.failure('my-msg', replies.GrpcStatus.AlreadyExists);
+    const reply = replies.failure('my-msg', GrpcStatus.AlreadyExists);
 
     expect(reply.isEmpty()).to.be.false;
     expect(reply.getMethod()).to.be.undefined;
@@ -59,9 +60,7 @@ describe('Replies', () => {
 
     expect(reply.getFailure()).to.not.be.undefined;
     expect(reply.getFailure()?.getDescription()).to.be.eq('my-msg');
-    expect(reply.getFailure()?.getStatus()).to.be.eq(
-      replies.GrpcStatus.AlreadyExists,
-    );
+    expect(reply.getFailure()?.getStatus()).to.be.eq(GrpcStatus.AlreadyExists);
   });
 
   it('should create a forward Reply', () => {


### PR DESCRIPTION
Will also need a forward port to the rename-branch

Note that in addition to making the `GrpcStatus` enum public in TS this also moved it from `akkaserverless.replies.GrpcStatus` directly to `akkaserverless.GrpcStatus`