### PR TITLE
chore: convert protobuf support to TypeScript

### DIFF
--- a/sdk/bin/prepare.sh
+++ b/sdk/bin/prepare.sh
@@ -42,7 +42,7 @@ echo "Generating TS type definitions based on JSDocs"
 cp index.d.preamble.ts index.d.ts
 jsdoc -t ./node_modules/@lightbend/tsd-jsdoc/dist -c ./jsdoc.json -d .
 cat types.d.ts >> index.d.ts && rm -f types.d.ts
-echo "Applying search-replace no generated TS to fix 'module:' entries"
+echo "Applying search-replace to generated TS to fix 'module:' entries"
 # There replacements are quite dirty, but even the patched tsd-jsdoc generator can't deal with these (mostly module related) issues currently
 perl -i -pe 's/declare module \"kalix\"/declare module \"\@kalix-io\/kalix-javascript-sdk\"/g' index.d.ts
 perl -i -pe 's/module:kalix\.//g' index.d.ts

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -356,6 +356,12 @@
       "integrity": "sha512-ubeqvw7sl6CdgeiIilsXB2jIFoD/D0F+/LIEp7xEBEXRNtDJcf05FRINybsJtL7GlkWOUVn6gJs2W9OF+xI6lg==",
       "dev": true
     },
+    "@types/json-stable-stringify": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.34.tgz",
+      "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==",
+      "dev": true
+    },
     "@types/linkify-it": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -49,6 +49,7 @@
     "@types/chai": "^4.2.19",
     "@types/debug": "^4.1.5",
     "@types/google-protobuf": "^3.15.2",
+    "@types/json-stable-stringify": "^1.0.34",
     "@types/mocha": "^8.2.2",
     "@types/node": "14.18.3",
     "chai": "4.2.0",

--- a/sdk/src/protobuf-any.jsdoc
+++ b/sdk/src/protobuf-any.jsdoc
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This is any type that has been returned by the protobufjs Message.create method.
+ *
+ * It should have a encode() method on it.
+ *
+ * @typedef module:kalix.SerializableProtobufMessage
+ * @type {Object}
+ */
+
+/**
+ * Any type that has a type property on it can be serialized as JSON, with the value of the type property describing
+ * the type of the value.
+ *
+ * @typedef module:kalix.TypedJson
+ * @type {Object}
+ * @property {string} type The type of the object.
+ */
+
+/**
+ * A type that is serializable.
+ *
+ * @typedef module:kalix.Serializable
+ * @type {module:kalix.SerializableProtobufMessage|module:kalix.TypedJson|Object|string|number|boolean|Long|Buffer}
+ */

--- a/sdk/src/protobuf-helper.ts
+++ b/sdk/src/protobuf-helper.ts
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-const fs = require('fs');
-const path = require('path');
-const protobuf = require('protobufjs');
+import fs from 'fs';
+import path from 'path';
+import protobuf from 'protobufjs';
 
-module.exports.loadSync = function (desc, includeDirs) {
+export function loadSync(
+  desc: string | string[],
+  includeDirs: string[],
+): protobuf.Root {
   const root = new protobuf.Root();
-  root.resolvePath = function (origin, target) {
+  root.resolvePath = function (_origin, target) {
     for (let i = 0; i < includeDirs.length; i++) {
       const directory = includeDirs[i];
       const fullPath = path.resolve(directory, target);
@@ -35,13 +38,13 @@ module.exports.loadSync = function (desc, includeDirs) {
   root.loadSync(desc);
   root.resolveAll();
   return root;
-};
+}
 
-module.exports.moduleIncludeDirs = [
+export const moduleIncludeDirs = [
   path.join(__dirname, '..', 'proto'),
   path.join(__dirname, '..', 'protoc', 'include'),
   path.join(__dirname, '..', '..', 'proto'),
   path.join(__dirname, '..', '..', 'protoc', 'include'),
 ];
 
-module.exports.moduleRoot = require('../proto/protobuf-bundle');
+export * as moduleRoot from '../proto/protobuf-bundle';


### PR DESCRIPTION
Refs #293. Breaking up into smaller steps. Only targeting `kalix-main` for this.

Convert the protobuf any support and tests to TypeScript. Direct translation, just add typing.