### PR TITLE
chore: change name template to version only

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
 # Config for https://github.com/release-drafter/release-drafter
-name-template: 'Kalix Javascript/Typescript SDK $NEXT_PATCH_VERSION'
+name-template: 'v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
   - title: '🚀 Features'


### PR DESCRIPTION
I think it's more useful to show the latest version right on the main page (same we have for akka). Any concern?
 
<img width="300" alt="Screenshot 2023-03-22 at 14 38 01" src="https://user-images.githubusercontent.com/1105359/226942986-48963486-1803-408e-8fb7-27b2f87b2745.png">


VS


<img width="300" alt="Screenshot 2023-03-22 at 14 38 36" src="https://user-images.githubusercontent.com/1105359/226942998-b6f0d3d5-a416-49a3-9031-6f1bd64dccc0.png">
